### PR TITLE
Fix compilation and tests under Go r60.3

### DIFF
--- a/lib/go/thrift/thttp_client.go
+++ b/lib/go/thrift/thttp_client.go
@@ -24,12 +24,13 @@ import (
   "http"
   "os"
   "strconv"
+  "url"
 )
 
 
 type THttpClient struct {
   response           *http.Response
-  url                *http.URL
+  url                *url.URL
   requestBuffer      *bytes.Buffer
   nsecConnectTimeout int64
   nsecReadTimeout    int64
@@ -69,20 +70,20 @@ func NewTHttpPostClientTransportFactory(url string) *THttpClientTransportFactory
 }
 
 
-func NewTHttpClient(url string) (TTransport, os.Error) {
-  parsedURL, err := http.ParseURL(url)
+func NewTHttpClient(urlstr string) (TTransport, os.Error) {
+  parsedURL, err := url.Parse(urlstr)
   if err != nil {
     return nil, err
   }
-  response, err := http.Get(url)
+  response, err := http.Get(urlstr)
   if err != nil {
     return nil, err
   }
   return &THttpClient{response: response, url: parsedURL}, nil
 }
 
-func NewTHttpPostClient(url string) (TTransport, os.Error) {
-  parsedURL, err := http.ParseURL(url)
+func NewTHttpPostClient(urlstr string) (TTransport, os.Error) {
+  parsedURL, err := url.Parse(urlstr)
   if err != nil {
     return nil, err
   }

--- a/lib/go/thrift/tjson_protocol_test.go
+++ b/lib/go/thrift/tjson_protocol_test.go
@@ -660,8 +660,8 @@ func TestReadWriteJSONStruct(t *testing.T) {
   }
   read := NewWork()
   e := read.Read(p)
-  t.Logf("Read %s value: %#v", thetype, read)
   if e != nil {
+    t.Logf("Read %s value: %#v", thetype, read)
     t.Fatalf("Unable to read %s due to error: %s", thetype, e.String())
   }
   if !orig.Equals(read) {

--- a/lib/go/thrift/tsimple_json_protocol_test.go
+++ b/lib/go/thrift/tsimple_json_protocol_test.go
@@ -578,7 +578,7 @@ func TestWriteSimpleJSONProtocolMap(t *testing.T) {
   if str[0] != '[' || str[len(str)-1] != ']' {
     t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
   }
-  l := strings.Split(str[1:len(str)-1], ",", -1)
+  l := strings.Split(str[1:len(str)-1], ",")
   if len(l) < 3 {
     t.Fatal("Expected list of at least length 3 for map for metadata, but was of length ", len(l))
   }
@@ -648,8 +648,8 @@ func TestReadWriteSimpleJSONStruct(t *testing.T) {
   t.Log("Memory buffer contents: ", trans.String())
   read := NewWork()
   e := read.Read(p)
-  t.Logf("Read %s value: %#v", thetype, read)
   if e != nil {
+    t.Logf("Read %s value: %#v", thetype, read)
     t.Fatalf("Unable to read %s due to error: %s", thetype, e.String())
   }
   if !orig.Equals(read) {


### PR DESCRIPTION
There was a change in r60 where URL is now under the url package rather than http. Also, there was a change to reflections in r60.3 that broke the tests giving the error "panic: reflect: call of reflect.Value.Type on zero Value". I fixed the tests, but it's quite possible there's a better way. I didn't look too much into it.

Info on r60 updates:
http://golang.org/doc/devel/release.html

The change to reflections in r60.3:
http://code.google.com/p/go/source/detail?r=01fa62f5e4e5
