### PR TITLE
Spurious break; in the helper for IsSet methods for enum types

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -1010,7 +1010,6 @@ void t_go_generator::generate_isset_helpers(ofstream& out,
         i_check_value = (field_default_value == NULL) ? 0 : field_default_value->get_integer();
         out << 
           indent() << "return int64(p." << field_name << ") != " << i_check_value << endl;
-        break;
       } else if(type->is_struct() || type->is_xception()) {
         out <<
           indent() << "return p." << field_name << " != nil" << endl;


### PR DESCRIPTION
While generating the bindings for the Cassandra thrift file I found out that the thrift4go generator (used with thrift 0.7.0) output invalid go code, a "}" was missing in the generated ttypes.go. I traced down the bug to a spurious "break;" inside the generator code. This pull request just removes the affected line.

Thank you for thrift4go, and I hope the recent changes get merged into mainline thrift soon!
