### PR TITLE
Use TType.ThriftTypeId in the binary protocol

### DIFF
--- a/lib/go/thrift/tbinary_protocol.go
+++ b/lib/go/thrift/tbinary_protocol.go
@@ -106,7 +106,7 @@ func (p *TBinaryProtocol) WriteStructEnd() TProtocolException {
 }
 
 func (p *TBinaryProtocol) WriteFieldBegin(name string, typeId TType, id int16) TProtocolException {
-  e := p.WriteByte(byte(typeId))
+  e := p.WriteByte(typeId.ThriftTypeId())
   if e != nil {
     return e
   }
@@ -124,11 +124,11 @@ func (p *TBinaryProtocol) WriteFieldStop() TProtocolException {
 }
 
 func (p *TBinaryProtocol) WriteMapBegin(keyType TType, valueType TType, size int) TProtocolException {
-  e := p.WriteByte(byte(keyType))
+  e := p.WriteByte(keyType.ThriftTypeId())
   if e != nil {
     return e
   }
-  e = p.WriteByte(byte(valueType))
+  e = p.WriteByte(valueType.ThriftTypeId())
   if e != nil {
     return e
   }
@@ -141,7 +141,7 @@ func (p *TBinaryProtocol) WriteMapEnd() TProtocolException {
 }
 
 func (p *TBinaryProtocol) WriteListBegin(elemType TType, size int) TProtocolException {
-  e := p.WriteByte(byte(elemType))
+  e := p.WriteByte(elemType.ThriftTypeId())
   if e != nil {
     return e
   }
@@ -154,7 +154,7 @@ func (p *TBinaryProtocol) WriteListEnd() TProtocolException {
 }
 
 func (p *TBinaryProtocol) WriteSetBegin(elemType TType, size int) TProtocolException {
-  e := p.WriteByte(byte(elemType))
+  e := p.WriteByte(elemType.ThriftTypeId())
   if e != nil {
     return e
   }


### PR DESCRIPTION
I have a Thrift server (Cassandra 1.0) that is barfing on BINARY fields. I've checked other language bindings and I see it available in some, and some others not, and the ones that have it appear to be aliasing it to STRING. Example tcpdump (cut down):

good:
00000014  63 71 6c 5f 71 75 65 72  79 00 00 00 01 0b 00 01 cql_quer y.......

bad:
00000014  63 71 6c 5f 71 75 65 72  79 00 00 00 01 12 00 01 cql_quer y.......

0xb = 11, the const for STRING, and 0x12 = 18, the const for BINARY. Other language bindings are outputing 0xb for binary TTypes.

From what I gather it was also the intention for the Go library, given that the method TType.ThriftTypeId exists and does just that, but it is unused right now. I've fixed tbinary_protocol.go to make sure the Write methods call this function so BINARY gets output as STRING. Maybe some other protocol writers need it too, like the compact one, but I can't test it.
