### PR TITLE
Use reflect.DeepEqual when comparing interface{} for better handling of slices, pass empty but optional byte slices

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -978,7 +978,7 @@ void t_go_generator::generate_isset_helpers(ofstream& out,
           if (((t_base_type*)type)->is_binary()) {
             // ignore default value for binary
             out << 
-              indent() << "return p." << field_name << " != nil && len(p." << field_name << ") > 0" << endl;
+              indent() << "return p." << field_name << " != nil" << endl;
           } else {
             s_check_value = (field_default_value == NULL) ? "\"\"" : render_const_value(type, field_default_value, tstruct_name);
             out << 

--- a/lib/go/thrift/ttype.go
+++ b/lib/go/thrift/ttype.go
@@ -25,6 +25,7 @@ import (
   "container/list"
   "container/vector"
   "strconv"
+  "reflect"
 )
 
 /**
@@ -374,7 +375,7 @@ func (p *tType) Less(i, j interface{}) bool {
 
 
 func (p *tType) Compare(i, j interface{}) (int, bool) {
-  if i == j {
+  if reflect.DeepEqual(i, j) {
     return 0, true
   }
   if i == nil {
@@ -398,7 +399,7 @@ func (p *tType) Compare(i, j interface{}) (int, bool) {
   if !iok && !jok {
     return 0, false
   }
-  if ci == cj {
+  if reflect.DeepEqual(ci, cj) {
     return 0, true
   }
   if ci == nil {


### PR DESCRIPTION
The recent changes for BINARY fields make usable some more Cassandra APIs, but I've found a small glitch in the Compare() function for thrift types. It tries to compare interfaces straight on, which will work for most of the native backing Go types, but not for the BINARY case, which has to be backed by a []byte ([]uint8) slice to work correctly.

This patch changes the == with calls to reflect.DeepEqual which is able to compare slices.

I've also included another commit which changes the behavior of BINARY optional struct fields in the generated Go code. With my change non-nil but empty byte slices will generate output. This is needed since empty BINARY fields are allowed and actually required for some Cassandra operations (GetRangeSlices parameter KeyRange for iterating over an entire column family for example)
