### PR TITLE
Use SetDeadline methods for socket timeout, update code with go fix

### DIFF
--- a/lib/go/thrift/tjson_protocol_test.go
+++ b/lib/go/thrift/tjson_protocol_test.go
@@ -20,654 +20,654 @@
 package thrift_test
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"math"
-	"strconv"
-	"testing"
-	. "thrift"
+  "encoding/base64"
+  "encoding/json"
+  "fmt"
+  "math"
+  "strconv"
+  "testing"
+  . "thrift"
 )
 
 func TestWriteJSONProtocolBool(t *testing.T) {
-	thetype := "boolean"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range BOOL_VALUES {
-		if e := p.WriteBool(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := false
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "boolean"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range BOOL_VALUES {
+    if e := p.WriteBool(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := false
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolBool(t *testing.T) {
-	thetype := "boolean"
-	for _, value := range BOOL_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		if value {
-			trans.Write(JSON_TRUE)
-		} else {
-			trans.Write(JSON_FALSE)
-		}
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadBool()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "boolean"
+  for _, value := range BOOL_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    if value {
+      trans.Write(JSON_TRUE)
+    } else {
+      trans.Write(JSON_FALSE)
+    }
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadBool()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolByte(t *testing.T) {
-	thetype := "byte"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range BYTE_VALUES {
-		if e := p.WriteByte(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := byte(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "byte"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range BYTE_VALUES {
+    if e := p.WriteByte(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := byte(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolByte(t *testing.T) {
-	thetype := "byte"
-	for _, value := range BYTE_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadByte()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "byte"
+  for _, value := range BYTE_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadByte()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolI16(t *testing.T) {
-	thetype := "int16"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range INT16_VALUES {
-		if e := p.WriteI16(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int16(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int16"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range INT16_VALUES {
+    if e := p.WriteI16(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int16(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolI16(t *testing.T) {
-	thetype := "int16"
-	for _, value := range INT16_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI16()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int16"
+  for _, value := range INT16_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI16()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolI32(t *testing.T) {
-	thetype := "int32"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range INT32_VALUES {
-		if e := p.WriteI32(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int32(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int32"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range INT32_VALUES {
+    if e := p.WriteI32(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int32(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolI32(t *testing.T) {
-	thetype := "int32"
-	for _, value := range INT32_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI32()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int32"
+  for _, value := range INT32_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI32()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolI64(t *testing.T) {
-	thetype := "int64"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range INT64_VALUES {
-		if e := p.WriteI64(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int64(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int64"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range INT64_VALUES {
+    if e := p.WriteI64(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int64(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolI64(t *testing.T) {
-	thetype := "int64"
-	for _, value := range INT64_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		trans.WriteString(strconv.FormatInt(value, 10))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI64()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int64"
+  for _, value := range INT64_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    trans.WriteString(strconv.FormatInt(value, 10))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI64()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolDouble(t *testing.T) {
-	thetype := "double"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if math.IsInf(value, 1) {
-			if s != JsonQuote(JSON_INFINITY) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
-			}
-		} else if math.IsInf(value, -1) {
-			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-			}
-		} else if math.IsNaN(value) {
-			if s != JsonQuote(JSON_NAN) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
-			}
-		} else {
-			if s != fmt.Sprint(value) {
-				t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-			}
-			v := float64(0)
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "double"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if math.IsInf(value, 1) {
+      if s != JsonQuote(JSON_INFINITY) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
+      }
+    } else if math.IsInf(value, -1) {
+      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+      }
+    } else if math.IsNaN(value) {
+      if s != JsonQuote(JSON_NAN) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
+      }
+    } else {
+      if s != fmt.Sprint(value) {
+        t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+      }
+      v := float64(0)
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolDouble(t *testing.T) {
-	thetype := "double"
-	for _, value := range DOUBLE_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		n := NewNumericFromDouble(value)
-		trans.WriteString(n.String())
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadDouble()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if math.IsInf(value, 1) {
-			if !math.IsInf(v, 1) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else if math.IsInf(value, -1) {
-			if !math.IsInf(v, -1) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else if math.IsNaN(value) {
-			if !math.IsNaN(v) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else {
-			if v != value {
-				t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "double"
+  for _, value := range DOUBLE_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    n := NewNumericFromDouble(value)
+    trans.WriteString(n.String())
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadDouble()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if math.IsInf(value, 1) {
+      if !math.IsInf(v, 1) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else if math.IsInf(value, -1) {
+      if !math.IsInf(v, -1) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else if math.IsNaN(value) {
+      if !math.IsNaN(v) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else {
+      if v != value {
+        t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolString(t *testing.T) {
-	thetype := "string"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	for _, value := range STRING_VALUES {
-		if e := p.WriteString(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s[0] != '"' || s[len(s)-1] != '"' {
-			t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
-		}
-		v := new(string)
-		if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "string"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  for _, value := range STRING_VALUES {
+    if e := p.WriteString(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s[0] != '"' || s[len(s)-1] != '"' {
+      t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
+    }
+    v := new(string)
+    if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolString(t *testing.T) {
-	thetype := "string"
-	for _, value := range STRING_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTJSONProtocol(trans)
-		trans.WriteString(JsonQuote(value))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadString()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		v1 := new(string)
-		if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "string"
+  for _, value := range STRING_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTJSONProtocol(trans)
+    trans.WriteString(JsonQuote(value))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadString()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    v1 := new(string)
+    if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteJSONProtocolBinary(t *testing.T) {
-	thetype := "binary"
-	value := protocol_bdata
-	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-	base64.StdEncoding.Encode(b64value, value)
-	b64String := string(b64value)
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	if e := p.WriteBinary(value); e != nil {
-		t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-	}
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-	}
-	s := trans.String()
-	expectedString := fmt.Sprint("\"", b64String, "\"")
-	if s != expectedString {
-		t.Fatalf("Bad value for %s %v\n  wrote:  \"%v\"\nexpected: \"%v\"", thetype, value, s, expectedString)
-	}
-	v1, err := p.ReadBinary()
-	if err != nil {
-		t.Fatalf("Unable to read binary: %s", err.Error())
-	}
-	if len(v1) != len(value) {
-		t.Fatalf("Invalid value for binary\nexpected: \"%v\"\n   read: \"%v\"", value, v1)
-	}
-	for k, v := range value {
-		if v1[k] != v {
-			t.Fatalf("Invalid value for binary at %v\nexpected: \"%v\"\n   read: \"%v\"", k, v, v1[k])
-		}
-	}
-	trans.Close()
+  thetype := "binary"
+  value := protocol_bdata
+  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+  base64.StdEncoding.Encode(b64value, value)
+  b64String := string(b64value)
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  if e := p.WriteBinary(value); e != nil {
+    t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+  }
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+  }
+  s := trans.String()
+  expectedString := fmt.Sprint("\"", b64String, "\"")
+  if s != expectedString {
+    t.Fatalf("Bad value for %s %v\n  wrote:  \"%v\"\nexpected: \"%v\"", thetype, value, s, expectedString)
+  }
+  v1, err := p.ReadBinary()
+  if err != nil {
+    t.Fatalf("Unable to read binary: %s", err.Error())
+  }
+  if len(v1) != len(value) {
+    t.Fatalf("Invalid value for binary\nexpected: \"%v\"\n   read: \"%v\"", value, v1)
+  }
+  for k, v := range value {
+    if v1[k] != v {
+      t.Fatalf("Invalid value for binary at %v\nexpected: \"%v\"\n   read: \"%v\"", k, v, v1[k])
+    }
+  }
+  trans.Close()
 }
 
 func TestReadJSONProtocolBinary(t *testing.T) {
-	thetype := "binary"
-	value := protocol_bdata
-	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-	base64.StdEncoding.Encode(b64value, value)
-	b64String := string(b64value)
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	trans.WriteString(JsonQuote(b64String))
-	trans.Flush()
-	s := trans.String()
-	v, e := p.ReadBinary()
-	if e != nil {
-		t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-	}
-	if len(v) != len(value) {
-		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
-	}
-	for i := 0; i < len(v); i++ {
-		if v[i] != value[i] {
-			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
-		}
-	}
-	v1 := new(string)
-	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-	}
-	trans.Reset()
-	trans.Close()
+  thetype := "binary"
+  value := protocol_bdata
+  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+  base64.StdEncoding.Encode(b64value, value)
+  b64String := string(b64value)
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  trans.WriteString(JsonQuote(b64String))
+  trans.Flush()
+  s := trans.String()
+  v, e := p.ReadBinary()
+  if e != nil {
+    t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+  }
+  if len(v) != len(value) {
+    t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
+  }
+  for i := 0; i < len(v); i++ {
+    if v[i] != value[i] {
+      t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
+    }
+  }
+  v1 := new(string)
+  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+  }
+  trans.Reset()
+  trans.Close()
 }
 
 func TestWriteJSONProtocolList(t *testing.T) {
-	thetype := "list"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteListEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	str1 := new([]interface{})
-	err := json.Unmarshal([]byte(str), str1)
-	if err != nil {
-		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-	}
-	l := *str1
-	if len(l) < 2 {
-		t.Fatalf("List must be at least of length two to include metadata")
-	}
-	if int(l[0].(float64)) != DOUBLE {
-		t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
-	}
-	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-		t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-	}
-	for k, value := range DOUBLE_VALUES {
-		s := l[k+2]
-		if math.IsInf(value, 1) {
-			if s.(string) != JSON_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-			}
-		} else if math.IsInf(value, 0) {
-			if s.(string) != JSON_NEGATIVE_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-			}
-		} else if math.IsNaN(value) {
-			if s.(string) != JSON_NAN {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-			}
-		} else {
-			if s.(float64) != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "list"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteListEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  str1 := new([]interface{})
+  err := json.Unmarshal([]byte(str), str1)
+  if err != nil {
+    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+  }
+  l := *str1
+  if len(l) < 2 {
+    t.Fatalf("List must be at least of length two to include metadata")
+  }
+  if int(l[0].(float64)) != DOUBLE {
+    t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
+  }
+  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+    t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+  }
+  for k, value := range DOUBLE_VALUES {
+    s := l[k+2]
+    if math.IsInf(value, 1) {
+      if s.(string) != JSON_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+      }
+    } else if math.IsInf(value, 0) {
+      if s.(string) != JSON_NEGATIVE_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+      }
+    } else if math.IsNaN(value) {
+      if s.(string) != JSON_NAN {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+      }
+    } else {
+      if s.(float64) != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestWriteJSONProtocolSet(t *testing.T) {
-	thetype := "set"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteSetEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	str1 := new([]interface{})
-	err := json.Unmarshal([]byte(str), str1)
-	if err != nil {
-		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-	}
-	l := *str1
-	if len(l) < 2 {
-		t.Fatalf("Set must be at least of length two to include metadata")
-	}
-	if int(l[0].(float64)) != DOUBLE {
-		t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
-	}
-	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-		t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-	}
-	for k, value := range DOUBLE_VALUES {
-		s := l[k+2]
-		if math.IsInf(value, 1) {
-			if s.(string) != JSON_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-			}
-		} else if math.IsInf(value, 0) {
-			if s.(string) != JSON_NEGATIVE_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-			}
-		} else if math.IsNaN(value) {
-			if s.(string) != JSON_NAN {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-			}
-		} else {
-			if s.(float64) != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "set"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteSetEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  str1 := new([]interface{})
+  err := json.Unmarshal([]byte(str), str1)
+  if err != nil {
+    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+  }
+  l := *str1
+  if len(l) < 2 {
+    t.Fatalf("Set must be at least of length two to include metadata")
+  }
+  if int(l[0].(float64)) != DOUBLE {
+    t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
+  }
+  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+    t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+  }
+  for k, value := range DOUBLE_VALUES {
+    s := l[k+2]
+    if math.IsInf(value, 1) {
+      if s.(string) != JSON_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+      }
+    } else if math.IsInf(value, 0) {
+      if s.(string) != JSON_NEGATIVE_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+      }
+    } else if math.IsNaN(value) {
+      if s.(string) != JSON_NAN {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+      }
+    } else {
+      if s.(float64) != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestWriteJSONProtocolMap(t *testing.T) {
-	thetype := "map"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
-	for k, value := range DOUBLE_VALUES {
-		if e := p.WriteI32(int32(k)); e != nil {
-			t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
-		}
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteMapEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	if str[0] != '[' || str[len(str)-1] != ']' {
-		t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
-	}
-	expectedKeyType, expectedValueType, expectedSize, err := p.ReadMapBegin()
-	if err != nil {
-		t.Fatalf("Error while reading map begin: %s", err.Error())
-	}
-	if expectedKeyType != I32 {
-		t.Fatal("Expected map key type ", I32, ", but was ", expectedKeyType)
-	}
-	if expectedValueType != DOUBLE {
-		t.Fatal("Expected map value type ", DOUBLE, ", but was ", expectedValueType)
-	}
-	if expectedSize != len(DOUBLE_VALUES) {
-		t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", expectedSize)
-	}
-	for k, value := range DOUBLE_VALUES {
-		ik, err := p.ReadI32()
-		if err != nil {
-			t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, ik, string(k), err.Error())
-		}
-		if int(ik) != k {
-			t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v", thetype, k, ik, k)
-		}
-		dv, err := p.ReadDouble()
-		if err != nil {
-			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, dv, value, err.Error())
-		}
-		s := strconv.FormatFloat(dv, 'g', 10, 64)
-		if math.IsInf(value, 1) {
-			if !math.IsInf(dv, 1) {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
-			}
-		} else if math.IsInf(value, 0) {
-			if !math.IsInf(dv, 0) {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-			}
-		} else if math.IsNaN(value) {
-			if !math.IsNaN(dv) {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
-			}
-		} else {
-			expected := strconv.FormatFloat(value, 'g', 10, 64)
-			if s != expected {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
-			}
-			v := float64(0)
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "map"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
+  for k, value := range DOUBLE_VALUES {
+    if e := p.WriteI32(int32(k)); e != nil {
+      t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
+    }
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteMapEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  if str[0] != '[' || str[len(str)-1] != ']' {
+    t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
+  }
+  expectedKeyType, expectedValueType, expectedSize, err := p.ReadMapBegin()
+  if err != nil {
+    t.Fatalf("Error while reading map begin: %s", err.Error())
+  }
+  if expectedKeyType != I32 {
+    t.Fatal("Expected map key type ", I32, ", but was ", expectedKeyType)
+  }
+  if expectedValueType != DOUBLE {
+    t.Fatal("Expected map value type ", DOUBLE, ", but was ", expectedValueType)
+  }
+  if expectedSize != len(DOUBLE_VALUES) {
+    t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", expectedSize)
+  }
+  for k, value := range DOUBLE_VALUES {
+    ik, err := p.ReadI32()
+    if err != nil {
+      t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, ik, string(k), err.Error())
+    }
+    if int(ik) != k {
+      t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v", thetype, k, ik, k)
+    }
+    dv, err := p.ReadDouble()
+    if err != nil {
+      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, dv, value, err.Error())
+    }
+    s := strconv.FormatFloat(dv, 'g', 10, 64)
+    if math.IsInf(value, 1) {
+      if !math.IsInf(dv, 1) {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
+      }
+    } else if math.IsInf(value, 0) {
+      if !math.IsInf(dv, 0) {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+      }
+    } else if math.IsNaN(value) {
+      if !math.IsNaN(dv) {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
+      }
+    } else {
+      expected := strconv.FormatFloat(value, 'g', 10, 64)
+      if s != expected {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
+      }
+      v := float64(0)
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadWriteJSONStruct(t *testing.T) {
-	thetype := "struct"
-	trans := NewTMemoryBuffer()
-	p := NewTJSONProtocol(trans)
-	orig := NewWork()
-	orig.Num1 = 25
-	orig.Num2 = 102
-	orig.Op = ADD
-	orig.Comment = "Add: 25 + 102"
-	if e := orig.Write(p); e != nil {
-		t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
-	}
-	p.Flush()
-	t.Log("Memory buffer contents: ", trans.String())
-	expectedString := "{\"1\":{\"i32\":25},\"2\":{\"i32\":102},\"3\":{\"i32\":1},\"4\":{\"str\":\"Add: 25 + 102\"}}"
-	if expectedString != trans.String() {
-		t.Fatalf("Expected JSON Struct with value %#v but have %#v", expectedString, trans.String())
-	}
-	read := NewWork()
-	e := read.Read(p)
-	t.Logf("Read %s value: %#v", thetype, read)
-	if e != nil {
-		t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
-	}
-	if !orig.Equals(read) {
-		t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
-	}
+  thetype := "struct"
+  trans := NewTMemoryBuffer()
+  p := NewTJSONProtocol(trans)
+  orig := NewWork()
+  orig.Num1 = 25
+  orig.Num2 = 102
+  orig.Op = ADD
+  orig.Comment = "Add: 25 + 102"
+  if e := orig.Write(p); e != nil {
+    t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
+  }
+  p.Flush()
+  t.Log("Memory buffer contents: ", trans.String())
+  expectedString := "{\"1\":{\"i32\":25},\"2\":{\"i32\":102},\"3\":{\"i32\":1},\"4\":{\"str\":\"Add: 25 + 102\"}}"
+  if expectedString != trans.String() {
+    t.Fatalf("Expected JSON Struct with value %#v but have %#v", expectedString, trans.String())
+  }
+  read := NewWork()
+  e := read.Read(p)
+  t.Logf("Read %s value: %#v", thetype, read)
+  if e != nil {
+    t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
+  }
+  if !orig.Equals(read) {
+    t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
+  }
 }
 
 func TestReadWriteJSONProtocol(t *testing.T) {
-	ReadWriteProtocolTest(t, NewTJSONProtocolFactory())
+  ReadWriteProtocolTest(t, NewTJSONProtocolFactory())
 }

--- a/lib/go/thrift/tjson_protocol_test.go
+++ b/lib/go/thrift/tjson_protocol_test.go
@@ -20,655 +20,654 @@
 package thrift_test
 
 import (
-  . "thrift"
-  "encoding/base64"
-  "fmt"
-  "encoding/json"
-  "math"
-  "strconv"
-  "testing"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+	. "thrift"
 )
 
 func TestWriteJSONProtocolBool(t *testing.T) {
-  thetype := "boolean"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range BOOL_VALUES {
-    if e := p.WriteBool(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := false
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "boolean"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range BOOL_VALUES {
+		if e := p.WriteBool(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := false
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolBool(t *testing.T) {
-  thetype := "boolean"
-  for _, value := range BOOL_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    if value {
-      trans.Write(JSON_TRUE)
-    } else {
-      trans.Write(JSON_FALSE)
-    }
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadBool()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "boolean"
+	for _, value := range BOOL_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		if value {
+			trans.Write(JSON_TRUE)
+		} else {
+			trans.Write(JSON_FALSE)
+		}
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadBool()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolByte(t *testing.T) {
-  thetype := "byte"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range BYTE_VALUES {
-    if e := p.WriteByte(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := byte(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "byte"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range BYTE_VALUES {
+		if e := p.WriteByte(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := byte(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolByte(t *testing.T) {
-  thetype := "byte"
-  for _, value := range BYTE_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadByte()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "byte"
+	for _, value := range BYTE_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadByte()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolI16(t *testing.T) {
-  thetype := "int16"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range INT16_VALUES {
-    if e := p.WriteI16(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int16(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int16"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range INT16_VALUES {
+		if e := p.WriteI16(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int16(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolI16(t *testing.T) {
-  thetype := "int16"
-  for _, value := range INT16_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI16()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int16"
+	for _, value := range INT16_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI16()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolI32(t *testing.T) {
-  thetype := "int32"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range INT32_VALUES {
-    if e := p.WriteI32(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int32(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int32"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range INT32_VALUES {
+		if e := p.WriteI32(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int32(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolI32(t *testing.T) {
-  thetype := "int32"
-  for _, value := range INT32_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI32()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int32"
+	for _, value := range INT32_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI32()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolI64(t *testing.T) {
-  thetype := "int64"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range INT64_VALUES {
-    if e := p.WriteI64(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int64(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int64"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range INT64_VALUES {
+		if e := p.WriteI64(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int64(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolI64(t *testing.T) {
-  thetype := "int64"
-  for _, value := range INT64_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa64(value))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI64()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int64"
+	for _, value := range INT64_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		trans.WriteString(strconv.FormatInt(value, 10))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI64()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolDouble(t *testing.T) {
-  thetype := "double"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if math.IsInf(value, 1) {
-      if s != JsonQuote(JSON_INFINITY) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
-      }
-    } else if math.IsInf(value, -1) {
-      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-      }
-    } else if math.IsNaN(value) {
-      if s != JsonQuote(JSON_NAN) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
-      }
-    } else {
-      if s != fmt.Sprint(value) {
-        t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-      }
-      v := float64(0)
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "double"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if math.IsInf(value, 1) {
+			if s != JsonQuote(JSON_INFINITY) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
+			}
+		} else if math.IsInf(value, -1) {
+			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+			}
+		} else if math.IsNaN(value) {
+			if s != JsonQuote(JSON_NAN) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
+			}
+		} else {
+			if s != fmt.Sprint(value) {
+				t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+			}
+			v := float64(0)
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolDouble(t *testing.T) {
-  thetype := "double"
-  for _, value := range DOUBLE_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    n := NewNumericFromDouble(value)
-    trans.WriteString(n.String())
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadDouble()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if math.IsInf(value, 1) {
-      if !math.IsInf(v, 1) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else if math.IsInf(value, -1) {
-      if !math.IsInf(v, -1) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else if math.IsNaN(value) {
-      if !math.IsNaN(v) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else {
-      if v != value {
-        t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "double"
+	for _, value := range DOUBLE_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		n := NewNumericFromDouble(value)
+		trans.WriteString(n.String())
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadDouble()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if math.IsInf(value, 1) {
+			if !math.IsInf(v, 1) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else if math.IsInf(value, -1) {
+			if !math.IsInf(v, -1) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else if math.IsNaN(value) {
+			if !math.IsNaN(v) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else {
+			if v != value {
+				t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolString(t *testing.T) {
-  thetype := "string"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  for _, value := range STRING_VALUES {
-    if e := p.WriteString(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s[0] != '"' || s[len(s)-1] != '"' {
-      t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
-    }
-    v := new(string)
-    if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "string"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	for _, value := range STRING_VALUES {
+		if e := p.WriteString(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s[0] != '"' || s[len(s)-1] != '"' {
+			t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
+		}
+		v := new(string)
+		if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolString(t *testing.T) {
-  thetype := "string"
-  for _, value := range STRING_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTJSONProtocol(trans)
-    trans.WriteString(JsonQuote(value))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadString()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    v1 := new(string)
-    if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "string"
+	for _, value := range STRING_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTJSONProtocol(trans)
+		trans.WriteString(JsonQuote(value))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadString()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		v1 := new(string)
+		if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteJSONProtocolBinary(t *testing.T) {
-  thetype := "binary"
-  value := protocol_bdata
-  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-  base64.StdEncoding.Encode(b64value, value)
-  b64String := string(b64value)
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  if e := p.WriteBinary(value); e != nil {
-    t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-  }
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-  }
-  s := trans.String()
-  expectedString := fmt.Sprint("\"", b64String, "\"")
-  if s != expectedString {
-    t.Fatalf("Bad value for %s %v\n  wrote:  \"%v\"\nexpected: \"%v\"", thetype, value, s, expectedString)
-  }
-  v1, err := p.ReadBinary()
-  if err != nil {
-    t.Fatalf("Unable to read binary: %s", err.Error())
-  }
-  if len(v1) != len(value) {
-    t.Fatalf("Invalid value for binary\nexpected: \"%v\"\n   read: \"%v\"", value, v1)
-  }
-  for k, v := range value {
-    if v1[k] != v {
-      t.Fatalf("Invalid value for binary at %v\nexpected: \"%v\"\n   read: \"%v\"", k, v, v1[k])
-    }
-  }
-  trans.Close()
+	thetype := "binary"
+	value := protocol_bdata
+	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+	base64.StdEncoding.Encode(b64value, value)
+	b64String := string(b64value)
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	if e := p.WriteBinary(value); e != nil {
+		t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+	}
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+	}
+	s := trans.String()
+	expectedString := fmt.Sprint("\"", b64String, "\"")
+	if s != expectedString {
+		t.Fatalf("Bad value for %s %v\n  wrote:  \"%v\"\nexpected: \"%v\"", thetype, value, s, expectedString)
+	}
+	v1, err := p.ReadBinary()
+	if err != nil {
+		t.Fatalf("Unable to read binary: %s", err.Error())
+	}
+	if len(v1) != len(value) {
+		t.Fatalf("Invalid value for binary\nexpected: \"%v\"\n   read: \"%v\"", value, v1)
+	}
+	for k, v := range value {
+		if v1[k] != v {
+			t.Fatalf("Invalid value for binary at %v\nexpected: \"%v\"\n   read: \"%v\"", k, v, v1[k])
+		}
+	}
+	trans.Close()
 }
 
 func TestReadJSONProtocolBinary(t *testing.T) {
-  thetype := "binary"
-  value := protocol_bdata
-  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-  base64.StdEncoding.Encode(b64value, value)
-  b64String := string(b64value)
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  trans.WriteString(JsonQuote(b64String))
-  trans.Flush()
-  s := trans.String()
-  v, e := p.ReadBinary()
-  if e != nil {
-    t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-  }
-  if len(v) != len(value) {
-    t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
-  }
-  for i := 0; i < len(v); i++ {
-    if v[i] != value[i] {
-      t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
-    }
-  }
-  v1 := new(string)
-  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-  }
-  trans.Reset()
-  trans.Close()
+	thetype := "binary"
+	value := protocol_bdata
+	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+	base64.StdEncoding.Encode(b64value, value)
+	b64String := string(b64value)
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	trans.WriteString(JsonQuote(b64String))
+	trans.Flush()
+	s := trans.String()
+	v, e := p.ReadBinary()
+	if e != nil {
+		t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+	}
+	if len(v) != len(value) {
+		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] != value[i] {
+			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
+		}
+	}
+	v1 := new(string)
+	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+	}
+	trans.Reset()
+	trans.Close()
 }
 
 func TestWriteJSONProtocolList(t *testing.T) {
-  thetype := "list"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteListEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  str1 := new([]interface{})
-  err := json.Unmarshal([]byte(str), str1)
-  if err != nil {
-    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-  }
-  l := *str1
-  if len(l) < 2 {
-    t.Fatalf("List must be at least of length two to include metadata")
-  }
-  if int(l[0].(float64)) != DOUBLE {
-    t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
-  }
-  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-    t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-  }
-  for k, value := range DOUBLE_VALUES {
-    s := l[k+2]
-    if math.IsInf(value, 1) {
-      if s.(string) != JSON_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-      }
-    } else if math.IsInf(value, 0) {
-      if s.(string) != JSON_NEGATIVE_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-      }
-    } else if math.IsNaN(value) {
-      if s.(string) != JSON_NAN {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-      }
-    } else {
-      if s.(float64) != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "list"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteListEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	str1 := new([]interface{})
+	err := json.Unmarshal([]byte(str), str1)
+	if err != nil {
+		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+	}
+	l := *str1
+	if len(l) < 2 {
+		t.Fatalf("List must be at least of length two to include metadata")
+	}
+	if int(l[0].(float64)) != DOUBLE {
+		t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
+	}
+	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+		t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+	}
+	for k, value := range DOUBLE_VALUES {
+		s := l[k+2]
+		if math.IsInf(value, 1) {
+			if s.(string) != JSON_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+			}
+		} else if math.IsInf(value, 0) {
+			if s.(string) != JSON_NEGATIVE_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+			}
+		} else if math.IsNaN(value) {
+			if s.(string) != JSON_NAN {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+			}
+		} else {
+			if s.(float64) != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestWriteJSONProtocolSet(t *testing.T) {
-  thetype := "set"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteSetEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  str1 := new([]interface{})
-  err := json.Unmarshal([]byte(str), str1)
-  if err != nil {
-    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-  }
-  l := *str1
-  if len(l) < 2 {
-    t.Fatalf("Set must be at least of length two to include metadata")
-  }
-  if int(l[0].(float64)) != DOUBLE {
-    t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
-  }
-  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-    t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-  }
-  for k, value := range DOUBLE_VALUES {
-    s := l[k+2]
-    if math.IsInf(value, 1) {
-      if s.(string) != JSON_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-      }
-    } else if math.IsInf(value, 0) {
-      if s.(string) != JSON_NEGATIVE_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-      }
-    } else if math.IsNaN(value) {
-      if s.(string) != JSON_NAN {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-      }
-    } else {
-      if s.(float64) != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "set"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteSetEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	str1 := new([]interface{})
+	err := json.Unmarshal([]byte(str), str1)
+	if err != nil {
+		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+	}
+	l := *str1
+	if len(l) < 2 {
+		t.Fatalf("Set must be at least of length two to include metadata")
+	}
+	if int(l[0].(float64)) != DOUBLE {
+		t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
+	}
+	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+		t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+	}
+	for k, value := range DOUBLE_VALUES {
+		s := l[k+2]
+		if math.IsInf(value, 1) {
+			if s.(string) != JSON_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+			}
+		} else if math.IsInf(value, 0) {
+			if s.(string) != JSON_NEGATIVE_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+			}
+		} else if math.IsNaN(value) {
+			if s.(string) != JSON_NAN {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+			}
+		} else {
+			if s.(float64) != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestWriteJSONProtocolMap(t *testing.T) {
-  thetype := "map"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
-  for k, value := range DOUBLE_VALUES {
-    if e := p.WriteI32(int32(k)); e != nil {
-      t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
-    }
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteMapEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  if str[0] != '[' || str[len(str)-1] != ']' {
-    t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
-  }
-  expectedKeyType, expectedValueType, expectedSize, err := p.ReadMapBegin()
-  if err != nil {
-    t.Fatalf("Error while reading map begin: %s", err.Error())
-  }
-  if expectedKeyType != I32 {
-    t.Fatal("Expected map key type ", I32, ", but was ", expectedKeyType)
-  }
-  if expectedValueType != DOUBLE {
-    t.Fatal("Expected map value type ", DOUBLE, ", but was ", expectedValueType)
-  }
-  if expectedSize != len(DOUBLE_VALUES) {
-    t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", expectedSize)
-  }
-  for k, value := range DOUBLE_VALUES {
-    ik, err := p.ReadI32()
-    if err != nil {
-      t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, ik, string(k), err.Error())
-    }
-    if int(ik) != k {
-      t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v", thetype, k, ik, k)
-    }
-    dv, err := p.ReadDouble()
-    if err != nil {
-      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, dv, value, err.Error())
-    }
-    s := strconv.Ftoa64(dv, 'g', 10)
-    if math.IsInf(value, 1) {
-      if !math.IsInf(dv, 1) {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
-      }
-    } else if math.IsInf(value, 0) {
-      if !math.IsInf(dv, 0) {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-      }
-    } else if math.IsNaN(value) {
-      if !math.IsNaN(dv) {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
-      }
-    } else {
-      expected := strconv.Ftoa64(value, 'g', 10)
-      if s != expected {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
-      }
-      v := float64(0)
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "map"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
+	for k, value := range DOUBLE_VALUES {
+		if e := p.WriteI32(int32(k)); e != nil {
+			t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
+		}
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteMapEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	if str[0] != '[' || str[len(str)-1] != ']' {
+		t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
+	}
+	expectedKeyType, expectedValueType, expectedSize, err := p.ReadMapBegin()
+	if err != nil {
+		t.Fatalf("Error while reading map begin: %s", err.Error())
+	}
+	if expectedKeyType != I32 {
+		t.Fatal("Expected map key type ", I32, ", but was ", expectedKeyType)
+	}
+	if expectedValueType != DOUBLE {
+		t.Fatal("Expected map value type ", DOUBLE, ", but was ", expectedValueType)
+	}
+	if expectedSize != len(DOUBLE_VALUES) {
+		t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", expectedSize)
+	}
+	for k, value := range DOUBLE_VALUES {
+		ik, err := p.ReadI32()
+		if err != nil {
+			t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, ik, string(k), err.Error())
+		}
+		if int(ik) != k {
+			t.Fatalf("Bad key for %s index %v, wrote: %v, expected: %v", thetype, k, ik, k)
+		}
+		dv, err := p.ReadDouble()
+		if err != nil {
+			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, dv, value, err.Error())
+		}
+		s := strconv.FormatFloat(dv, 'g', 10, 64)
+		if math.IsInf(value, 1) {
+			if !math.IsInf(dv, 1) {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
+			}
+		} else if math.IsInf(value, 0) {
+			if !math.IsInf(dv, 0) {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+			}
+		} else if math.IsNaN(value) {
+			if !math.IsNaN(dv) {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
+			}
+		} else {
+			expected := strconv.FormatFloat(value, 'g', 10, 64)
+			if s != expected {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
+			}
+			v := float64(0)
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
-
 func TestReadWriteJSONStruct(t *testing.T) {
-  thetype := "struct"
-  trans := NewTMemoryBuffer()
-  p := NewTJSONProtocol(trans)
-  orig := NewWork()
-  orig.Num1 = 25
-  orig.Num2 = 102
-  orig.Op = ADD
-  orig.Comment = "Add: 25 + 102"
-  if e := orig.Write(p); e != nil {
-    t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
-  }
-  p.Flush()
-  t.Log("Memory buffer contents: ", trans.String())
-  expectedString := "{\"1\":{\"i32\":25},\"2\":{\"i32\":102},\"3\":{\"i32\":1},\"4\":{\"str\":\"Add: 25 + 102\"}}"
-  if expectedString != trans.String() {
-    t.Fatalf("Expected JSON Struct with value %#v but have %#v", expectedString, trans.String())
-  }
-  read := NewWork()
-  e := read.Read(p)
-  t.Logf("Read %s value: %#v", thetype, read)
-  if e != nil {
-    t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
-  }
-  if !orig.Equals(read) {
-    t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
-  }
+	thetype := "struct"
+	trans := NewTMemoryBuffer()
+	p := NewTJSONProtocol(trans)
+	orig := NewWork()
+	orig.Num1 = 25
+	orig.Num2 = 102
+	orig.Op = ADD
+	orig.Comment = "Add: 25 + 102"
+	if e := orig.Write(p); e != nil {
+		t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
+	}
+	p.Flush()
+	t.Log("Memory buffer contents: ", trans.String())
+	expectedString := "{\"1\":{\"i32\":25},\"2\":{\"i32\":102},\"3\":{\"i32\":1},\"4\":{\"str\":\"Add: 25 + 102\"}}"
+	if expectedString != trans.String() {
+		t.Fatalf("Expected JSON Struct with value %#v but have %#v", expectedString, trans.String())
+	}
+	read := NewWork()
+	e := read.Read(p)
+	t.Logf("Read %s value: %#v", thetype, read)
+	if e != nil {
+		t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
+	}
+	if !orig.Equals(read) {
+		t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
+	}
 }
 
 func TestReadWriteJSONProtocol(t *testing.T) {
-  ReadWriteProtocolTest(t, NewTJSONProtocolFactory())
+	ReadWriteProtocolTest(t, NewTJSONProtocolFactory())
 }

--- a/lib/go/thrift/tnonblocking_server_socket.go
+++ b/lib/go/thrift/tnonblocking_server_socket.go
@@ -140,7 +140,8 @@ func (p *TNonblockingServerSocket) Accept() (TTransport, error) {
   if err != nil {
     return nil, NewTTransportExceptionFromOsError(err)
   }
-  conn.SetTimeout(p.nsecTimeout)
+  // This only makes sense in the context of calling Read/Write, not here as a direct replacement of SetTimeout()
+  // conn.SetDeadline(time.Now().Add(time.Duration(p.nsecTimeout)))
   return NewTSocketConn(conn)
 }
 

--- a/lib/go/thrift/tnonblocking_transport_test.go
+++ b/lib/go/thrift/tnonblocking_transport_test.go
@@ -40,8 +40,8 @@ func TestNonblockingTransportServerToClient(t *testing.T) {
   if err != nil {
     t.Fatalf("Unable to setup client socket: %s", err)
   }
-  trans1.SetTimeout(10)
-  trans2.SetTimeout(10)
+  trans1.SetTimeout(1e9)
+  trans2.SetTimeout(1e9)
   err = trans2.Open()
   if err != nil {
     t.Fatalf("Unable to connect client to server: %s", err)
@@ -72,8 +72,8 @@ func TestNonblockingTransportClientToServer(t *testing.T) {
   if err != nil {
     t.Fatalf("Unable to setup client socket: %s", err)
   }
-  trans1.SetTimeout(10)
-  trans2.SetTimeout(10)
+  trans1.SetTimeout(1e9)
+  trans2.SetTimeout(1e9)
   err = trans2.Open()
   if err != nil {
     t.Fatalf("Unable to connect client to server: %s", err)

--- a/lib/go/thrift/tserver_socket.go
+++ b/lib/go/thrift/tserver_socket.go
@@ -72,7 +72,8 @@ func NewTServerSocketConn(conn net.Conn) *TServerSocket {
 
 func NewTServerSocketConnTimeout(conn net.Conn, nsecClientTimeout int64) *TServerSocket {
   v := &TServerSocket{conn: conn, addr: conn.LocalAddr(), nsecClientTimeout: nsecClientTimeout}
-  conn.SetTimeout(nsecClientTimeout)
+  // This only makes sense in the context of calling Read/Write, not here as a direct replacement of SetTimeout()
+  // conn.SetDeadline(time.Now().Add(time.Duration(nsecClientTimeout)))
   return v
 }
 
@@ -107,7 +108,8 @@ func (p *TServerSocket) Accept() (TTransport, error) {
   if err != nil {
     return nil, NewTTransportExceptionFromOsError(err)
   }
-  conn.SetTimeout(p.nsecClientTimeout)
+  // This only makes sense in the context of calling Read/Write, not here as a direct replacement of SetTimeout()
+  // conn.SetDeadline(time.Now().Add(time.Duration(p.nsecTimeout)))
   return NewTSocketConn(conn)
 }
 

--- a/lib/go/thrift/tsimple_json_protocol_test.go
+++ b/lib/go/thrift/tsimple_json_protocol_test.go
@@ -20,642 +20,642 @@
 package thrift_test
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"math"
-	"strconv"
-	"strings"
-	"testing"
-	. "thrift"
+  "encoding/base64"
+  "encoding/json"
+  "fmt"
+  "math"
+  "strconv"
+  "strings"
+  "testing"
+  . "thrift"
 )
 
 func TestWriteSimpleJSONProtocolBool(t *testing.T) {
-	thetype := "boolean"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range BOOL_VALUES {
-		if e := p.WriteBool(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := false
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "boolean"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range BOOL_VALUES {
+    if e := p.WriteBool(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := false
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolBool(t *testing.T) {
-	thetype := "boolean"
-	for _, value := range BOOL_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		if value {
-			trans.Write(JSON_TRUE)
-		} else {
-			trans.Write(JSON_FALSE)
-		}
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadBool()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "boolean"
+  for _, value := range BOOL_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    if value {
+      trans.Write(JSON_TRUE)
+    } else {
+      trans.Write(JSON_FALSE)
+    }
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadBool()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolByte(t *testing.T) {
-	thetype := "byte"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range BYTE_VALUES {
-		if e := p.WriteByte(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := byte(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "byte"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range BYTE_VALUES {
+    if e := p.WriteByte(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := byte(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolByte(t *testing.T) {
-	thetype := "byte"
-	for _, value := range BYTE_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadByte()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "byte"
+  for _, value := range BYTE_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadByte()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolI16(t *testing.T) {
-	thetype := "int16"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range INT16_VALUES {
-		if e := p.WriteI16(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int16(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int16"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range INT16_VALUES {
+    if e := p.WriteI16(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int16(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI16(t *testing.T) {
-	thetype := "int16"
-	for _, value := range INT16_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI16()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int16"
+  for _, value := range INT16_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI16()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolI32(t *testing.T) {
-	thetype := "int32"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range INT32_VALUES {
-		if e := p.WriteI32(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int32(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int32"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range INT32_VALUES {
+    if e := p.WriteI32(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int32(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI32(t *testing.T) {
-	thetype := "int32"
-	for _, value := range INT32_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		trans.WriteString(strconv.Itoa(int(value)))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI32()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int32"
+  for _, value := range INT32_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    trans.WriteString(strconv.Itoa(int(value)))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI32()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolI64(t *testing.T) {
-	thetype := "int64"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range INT64_VALUES {
-		if e := p.WriteI64(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s != fmt.Sprint(value) {
-			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-		}
-		v := int64(0)
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "int64"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range INT64_VALUES {
+    if e := p.WriteI64(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s != fmt.Sprint(value) {
+      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+    }
+    v := int64(0)
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI64(t *testing.T) {
-	thetype := "int64"
-	for _, value := range INT64_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		trans.WriteString(strconv.FormatInt(value, 10))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadI64()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "int64"
+  for _, value := range INT64_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    trans.WriteString(strconv.FormatInt(value, 10))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadI64()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolDouble(t *testing.T) {
-	thetype := "double"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if math.IsInf(value, 1) {
-			if s != JsonQuote(JSON_INFINITY) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
-			}
-		} else if math.IsInf(value, -1) {
-			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-			}
-		} else if math.IsNaN(value) {
-			if s != JsonQuote(JSON_NAN) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
-			}
-		} else {
-			if s != fmt.Sprint(value) {
-				t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-			}
-			v := float64(0)
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "double"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if math.IsInf(value, 1) {
+      if s != JsonQuote(JSON_INFINITY) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
+      }
+    } else if math.IsInf(value, -1) {
+      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+      }
+    } else if math.IsNaN(value) {
+      if s != JsonQuote(JSON_NAN) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
+      }
+    } else {
+      if s != fmt.Sprint(value) {
+        t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+      }
+      v := float64(0)
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolDouble(t *testing.T) {
-	thetype := "double"
-	for _, value := range DOUBLE_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		n := NewNumericFromDouble(value)
-		trans.WriteString(n.String())
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadDouble()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if math.IsInf(value, 1) {
-			if !math.IsInf(v, 1) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else if math.IsInf(value, -1) {
-			if !math.IsInf(v, -1) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else if math.IsNaN(value) {
-			if !math.IsNaN(v) {
-				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-		} else {
-			if v != value {
-				t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-			}
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "double"
+  for _, value := range DOUBLE_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    n := NewNumericFromDouble(value)
+    trans.WriteString(n.String())
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadDouble()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if math.IsInf(value, 1) {
+      if !math.IsInf(v, 1) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else if math.IsInf(value, -1) {
+      if !math.IsInf(v, -1) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else if math.IsNaN(value) {
+      if !math.IsNaN(v) {
+        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+    } else {
+      if v != value {
+        t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+      }
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolString(t *testing.T) {
-	thetype := "string"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	for _, value := range STRING_VALUES {
-		if e := p.WriteString(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if e := p.Flush(); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-		}
-		s := trans.String()
-		if s[0] != '"' || s[len(s)-1] != '"' {
-			t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
-		}
-		v := new(string)
-		if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "string"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  for _, value := range STRING_VALUES {
+    if e := p.WriteString(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if e := p.Flush(); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+    }
+    s := trans.String()
+    if s[0] != '"' || s[len(s)-1] != '"' {
+      t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
+    }
+    v := new(string)
+    if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolString(t *testing.T) {
-	thetype := "string"
-	for _, value := range STRING_VALUES {
-		trans := NewTMemoryBuffer()
-		p := NewTSimpleJSONProtocol(trans)
-		trans.WriteString(JsonQuote(value))
-		trans.Flush()
-		s := trans.String()
-		v, e := p.ReadString()
-		if e != nil {
-			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-		}
-		if v != value {
-			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-		}
-		v1 := new(string)
-		if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
-			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-		}
-		trans.Reset()
-		trans.Close()
-	}
+  thetype := "string"
+  for _, value := range STRING_VALUES {
+    trans := NewTMemoryBuffer()
+    p := NewTSimpleJSONProtocol(trans)
+    trans.WriteString(JsonQuote(value))
+    trans.Flush()
+    s := trans.String()
+    v, e := p.ReadString()
+    if e != nil {
+      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+    }
+    if v != value {
+      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+    }
+    v1 := new(string)
+    if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
+      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+    }
+    trans.Reset()
+    trans.Close()
+  }
 }
 
 func TestWriteSimpleJSONProtocolBinary(t *testing.T) {
-	thetype := "binary"
-	value := protocol_bdata
-	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-	base64.StdEncoding.Encode(b64value, value)
-	b64String := string(b64value)
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	if e := p.WriteBinary(value); e != nil {
-		t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-	}
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-	}
-	s := trans.String()
-	if s != fmt.Sprint("\"", b64String, "\"") {
-		t.Fatalf("Bad value for %s %v\n  wrote: %v\nexpected: %v", thetype, value, s, "\""+b64String+"\"")
-	}
-	v1 := new(string)
-	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-	}
-	trans.Close()
+  thetype := "binary"
+  value := protocol_bdata
+  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+  base64.StdEncoding.Encode(b64value, value)
+  b64String := string(b64value)
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  if e := p.WriteBinary(value); e != nil {
+    t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+  }
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+  }
+  s := trans.String()
+  if s != fmt.Sprint("\"", b64String, "\"") {
+    t.Fatalf("Bad value for %s %v\n  wrote: %v\nexpected: %v", thetype, value, s, "\""+b64String+"\"")
+  }
+  v1 := new(string)
+  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+  }
+  trans.Close()
 }
 
 func TestReadSimpleJSONProtocolBinary(t *testing.T) {
-	thetype := "binary"
-	value := protocol_bdata
-	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-	base64.StdEncoding.Encode(b64value, value)
-	b64String := string(b64value)
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	trans.WriteString(JsonQuote(b64String))
-	trans.Flush()
-	s := trans.String()
-	v, e := p.ReadBinary()
-	if e != nil {
-		t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-	}
-	if len(v) != len(value) {
-		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
-	}
-	for i := 0; i < len(v); i++ {
-		if v[i] != value[i] {
-			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
-		}
-	}
-	v1 := new(string)
-	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-	}
-	trans.Reset()
-	trans.Close()
+  thetype := "binary"
+  value := protocol_bdata
+  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+  base64.StdEncoding.Encode(b64value, value)
+  b64String := string(b64value)
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  trans.WriteString(JsonQuote(b64String))
+  trans.Flush()
+  s := trans.String()
+  v, e := p.ReadBinary()
+  if e != nil {
+    t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+  }
+  if len(v) != len(value) {
+    t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
+  }
+  for i := 0; i < len(v); i++ {
+    if v[i] != value[i] {
+      t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
+    }
+  }
+  v1 := new(string)
+  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+  }
+  trans.Reset()
+  trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolList(t *testing.T) {
-	thetype := "list"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteListEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	str1 := new([]interface{})
-	err := json.Unmarshal([]byte(str), str1)
-	if err != nil {
-		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-	}
-	l := *str1
-	if len(l) < 2 {
-		t.Fatalf("List must be at least of length two to include metadata")
-	}
-	if int(l[0].(float64)) != DOUBLE {
-		t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
-	}
-	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-		t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-	}
-	for k, value := range DOUBLE_VALUES {
-		s := l[k+2]
-		if math.IsInf(value, 1) {
-			if s.(string) != JSON_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-			}
-		} else if math.IsInf(value, 0) {
-			if s.(string) != JSON_NEGATIVE_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-			}
-		} else if math.IsNaN(value) {
-			if s.(string) != JSON_NAN {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-			}
-		} else {
-			if s.(float64) != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "list"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteListEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  str1 := new([]interface{})
+  err := json.Unmarshal([]byte(str), str1)
+  if err != nil {
+    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+  }
+  l := *str1
+  if len(l) < 2 {
+    t.Fatalf("List must be at least of length two to include metadata")
+  }
+  if int(l[0].(float64)) != DOUBLE {
+    t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
+  }
+  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+    t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+  }
+  for k, value := range DOUBLE_VALUES {
+    s := l[k+2]
+    if math.IsInf(value, 1) {
+      if s.(string) != JSON_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+      }
+    } else if math.IsInf(value, 0) {
+      if s.(string) != JSON_NEGATIVE_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+      }
+    } else if math.IsNaN(value) {
+      if s.(string) != JSON_NAN {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+      }
+    } else {
+      if s.(float64) != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolSet(t *testing.T) {
-	thetype := "set"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-	for _, value := range DOUBLE_VALUES {
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteSetEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	str1 := new([]interface{})
-	err := json.Unmarshal([]byte(str), str1)
-	if err != nil {
-		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-	}
-	l := *str1
-	if len(l) < 2 {
-		t.Fatalf("Set must be at least of length two to include metadata")
-	}
-	if int(l[0].(float64)) != DOUBLE {
-		t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
-	}
-	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-		t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-	}
-	for k, value := range DOUBLE_VALUES {
-		s := l[k+2]
-		if math.IsInf(value, 1) {
-			if s.(string) != JSON_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-			}
-		} else if math.IsInf(value, 0) {
-			if s.(string) != JSON_NEGATIVE_INFINITY {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-			}
-		} else if math.IsNaN(value) {
-			if s.(string) != JSON_NAN {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-			}
-		} else {
-			if s.(float64) != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "set"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+  for _, value := range DOUBLE_VALUES {
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteSetEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  str1 := new([]interface{})
+  err := json.Unmarshal([]byte(str), str1)
+  if err != nil {
+    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+  }
+  l := *str1
+  if len(l) < 2 {
+    t.Fatalf("Set must be at least of length two to include metadata")
+  }
+  if int(l[0].(float64)) != DOUBLE {
+    t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
+  }
+  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+    t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+  }
+  for k, value := range DOUBLE_VALUES {
+    s := l[k+2]
+    if math.IsInf(value, 1) {
+      if s.(string) != JSON_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+      }
+    } else if math.IsInf(value, 0) {
+      if s.(string) != JSON_NEGATIVE_INFINITY {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+      }
+    } else if math.IsNaN(value) {
+      if s.(string) != JSON_NAN {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+      }
+    } else {
+      if s.(float64) != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolMap(t *testing.T) {
-	thetype := "map"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
-	for k, value := range DOUBLE_VALUES {
-		if e := p.WriteI32(int32(k)); e != nil {
-			t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
-		}
-		if e := p.WriteDouble(value); e != nil {
-			t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
-		}
-	}
-	p.WriteMapEnd()
-	if e := p.Flush(); e != nil {
-		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-	}
-	str := trans.String()
-	if str[0] != '[' || str[len(str)-1] != ']' {
-		t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
-	}
-	l := strings.Split(str[1:len(str)-1], ",")
-	if len(l) < 3 {
-		t.Fatal("Expected list of at least length 3 for map for metadata, but was of length ", len(l))
-	}
-	expectedKeyType, _ := strconv.Atoi(l[0])
-	expectedValueType, _ := strconv.Atoi(l[1])
-	expectedSize, _ := strconv.Atoi(l[2])
-	if expectedKeyType != I32 {
-		t.Fatal("Expected map key type ", I32, ", but was ", l[0])
-	}
-	if expectedValueType != DOUBLE {
-		t.Fatal("Expected map value type ", DOUBLE, ", but was ", l[1])
-	}
-	if expectedSize != len(DOUBLE_VALUES) {
-		t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", l[2])
-	}
-	for k, value := range DOUBLE_VALUES {
-		strk := l[k*2+3]
-		strv := l[k*2+4]
-		ik, err := strconv.Atoi(strk)
-		if err != nil {
-			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, strk, string(k), err.Error())
-		}
-		if ik != k {
-			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v", thetype, k, strk, k)
-		}
-		s := strv
-		if math.IsInf(value, 1) {
-			if s != JsonQuote(JSON_INFINITY) {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
-			}
-		} else if math.IsInf(value, 0) {
-			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-			}
-		} else if math.IsNaN(value) {
-			if s != JsonQuote(JSON_NAN) {
-				t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
-			}
-		} else {
-			expected := strconv.FormatFloat(value, 'g', 10, 64)
-			if s != expected {
-				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
-			}
-			v := float64(0)
-			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-			}
-		}
-		trans.Reset()
-	}
-	trans.Close()
+  thetype := "map"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
+  for k, value := range DOUBLE_VALUES {
+    if e := p.WriteI32(int32(k)); e != nil {
+      t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
+    }
+    if e := p.WriteDouble(value); e != nil {
+      t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
+    }
+  }
+  p.WriteMapEnd()
+  if e := p.Flush(); e != nil {
+    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+  }
+  str := trans.String()
+  if str[0] != '[' || str[len(str)-1] != ']' {
+    t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
+  }
+  l := strings.Split(str[1:len(str)-1], ",")
+  if len(l) < 3 {
+    t.Fatal("Expected list of at least length 3 for map for metadata, but was of length ", len(l))
+  }
+  expectedKeyType, _ := strconv.Atoi(l[0])
+  expectedValueType, _ := strconv.Atoi(l[1])
+  expectedSize, _ := strconv.Atoi(l[2])
+  if expectedKeyType != I32 {
+    t.Fatal("Expected map key type ", I32, ", but was ", l[0])
+  }
+  if expectedValueType != DOUBLE {
+    t.Fatal("Expected map value type ", DOUBLE, ", but was ", l[1])
+  }
+  if expectedSize != len(DOUBLE_VALUES) {
+    t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", l[2])
+  }
+  for k, value := range DOUBLE_VALUES {
+    strk := l[k*2+3]
+    strv := l[k*2+4]
+    ik, err := strconv.Atoi(strk)
+    if err != nil {
+      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, strk, string(k), err.Error())
+    }
+    if ik != k {
+      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v", thetype, k, strk, k)
+    }
+    s := strv
+    if math.IsInf(value, 1) {
+      if s != JsonQuote(JSON_INFINITY) {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
+      }
+    } else if math.IsInf(value, 0) {
+      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+      }
+    } else if math.IsNaN(value) {
+      if s != JsonQuote(JSON_NAN) {
+        t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
+      }
+    } else {
+      expected := strconv.FormatFloat(value, 'g', 10, 64)
+      if s != expected {
+        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
+      }
+      v := float64(0)
+      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+      }
+    }
+    trans.Reset()
+  }
+  trans.Close()
 }
 
 func TestReadWriteSimpleJSONStruct(t *testing.T) {
-	thetype := "struct"
-	trans := NewTMemoryBuffer()
-	p := NewTSimpleJSONProtocol(trans)
-	orig := NewWork()
-	orig.Num1 = 25
-	orig.Num2 = 102
-	orig.Op = ADD
-	orig.Comment = "Add: 25 + 102"
-	if e := orig.Write(p); e != nil {
-		t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
-	}
-	t.Log("Memory buffer contents: ", trans.String())
-	read := NewWork()
-	e := read.Read(p)
-	t.Logf("Read %s value: %#v", thetype, read)
-	if e != nil {
-		t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
-	}
-	if !orig.Equals(read) {
-		t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
-	}
+  thetype := "struct"
+  trans := NewTMemoryBuffer()
+  p := NewTSimpleJSONProtocol(trans)
+  orig := NewWork()
+  orig.Num1 = 25
+  orig.Num2 = 102
+  orig.Op = ADD
+  orig.Comment = "Add: 25 + 102"
+  if e := orig.Write(p); e != nil {
+    t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
+  }
+  t.Log("Memory buffer contents: ", trans.String())
+  read := NewWork()
+  e := read.Read(p)
+  t.Logf("Read %s value: %#v", thetype, read)
+  if e != nil {
+    t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
+  }
+  if !orig.Equals(read) {
+    t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
+  }
 }
 
 func TestReadWriteSimpleJSONProtocol(t *testing.T) {
-	ReadWriteProtocolTest(t, NewTSimpleJSONProtocolFactory())
+  ReadWriteProtocolTest(t, NewTSimpleJSONProtocolFactory())
 }

--- a/lib/go/thrift/tsimple_json_protocol_test.go
+++ b/lib/go/thrift/tsimple_json_protocol_test.go
@@ -20,643 +20,642 @@
 package thrift_test
 
 import (
-  . "thrift"
-  "encoding/base64"
-  "fmt"
-  "encoding/json"
-  "math"
-  "strconv"
-  "strings"
-  "testing"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+	. "thrift"
 )
 
 func TestWriteSimpleJSONProtocolBool(t *testing.T) {
-  thetype := "boolean"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range BOOL_VALUES {
-    if e := p.WriteBool(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := false
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "boolean"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range BOOL_VALUES {
+		if e := p.WriteBool(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := false
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolBool(t *testing.T) {
-  thetype := "boolean"
-  for _, value := range BOOL_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    if value {
-      trans.Write(JSON_TRUE)
-    } else {
-      trans.Write(JSON_FALSE)
-    }
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadBool()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "boolean"
+	for _, value := range BOOL_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		if value {
+			trans.Write(JSON_TRUE)
+		} else {
+			trans.Write(JSON_FALSE)
+		}
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadBool()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolByte(t *testing.T) {
-  thetype := "byte"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range BYTE_VALUES {
-    if e := p.WriteByte(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := byte(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "byte"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range BYTE_VALUES {
+		if e := p.WriteByte(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := byte(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolByte(t *testing.T) {
-  thetype := "byte"
-  for _, value := range BYTE_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadByte()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "byte"
+	for _, value := range BYTE_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadByte()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolI16(t *testing.T) {
-  thetype := "int16"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range INT16_VALUES {
-    if e := p.WriteI16(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int16(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int16"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range INT16_VALUES {
+		if e := p.WriteI16(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int16(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI16(t *testing.T) {
-  thetype := "int16"
-  for _, value := range INT16_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI16()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int16"
+	for _, value := range INT16_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI16()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolI32(t *testing.T) {
-  thetype := "int32"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range INT32_VALUES {
-    if e := p.WriteI32(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int32(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int32"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range INT32_VALUES {
+		if e := p.WriteI32(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int32(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI32(t *testing.T) {
-  thetype := "int32"
-  for _, value := range INT32_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa(int(value)))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI32()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int32"
+	for _, value := range INT32_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		trans.WriteString(strconv.Itoa(int(value)))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI32()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolI64(t *testing.T) {
-  thetype := "int64"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range INT64_VALUES {
-    if e := p.WriteI64(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s != fmt.Sprint(value) {
-      t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-    }
-    v := int64(0)
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "int64"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range INT64_VALUES {
+		if e := p.WriteI64(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s != fmt.Sprint(value) {
+			t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+		}
+		v := int64(0)
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolI64(t *testing.T) {
-  thetype := "int64"
-  for _, value := range INT64_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    trans.WriteString(strconv.Itoa64(value))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadI64()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "int64"
+	for _, value := range INT64_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		trans.WriteString(strconv.FormatInt(value, 10))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadI64()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolDouble(t *testing.T) {
-  thetype := "double"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if math.IsInf(value, 1) {
-      if s != JsonQuote(JSON_INFINITY) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
-      }
-    } else if math.IsInf(value, -1) {
-      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-      }
-    } else if math.IsNaN(value) {
-      if s != JsonQuote(JSON_NAN) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
-      }
-    } else {
-      if s != fmt.Sprint(value) {
-        t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
-      }
-      v := float64(0)
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "double"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if math.IsInf(value, 1) {
+			if s != JsonQuote(JSON_INFINITY) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_INFINITY))
+			}
+		} else if math.IsInf(value, -1) {
+			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+			}
+		} else if math.IsNaN(value) {
+			if s != JsonQuote(JSON_NAN) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, expected: %v", thetype, value, s, JsonQuote(JSON_NAN))
+			}
+		} else {
+			if s != fmt.Sprint(value) {
+				t.Fatalf("Bad value for %s %v: %s", thetype, value, s)
+			}
+			v := float64(0)
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolDouble(t *testing.T) {
-  thetype := "double"
-  for _, value := range DOUBLE_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    n := NewNumericFromDouble(value)
-    trans.WriteString(n.String())
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadDouble()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if math.IsInf(value, 1) {
-      if !math.IsInf(v, 1) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else if math.IsInf(value, -1) {
-      if !math.IsInf(v, -1) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else if math.IsNaN(value) {
-      if !math.IsNaN(v) {
-        t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-    } else {
-      if v != value {
-        t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-      }
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "double"
+	for _, value := range DOUBLE_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		n := NewNumericFromDouble(value)
+		trans.WriteString(n.String())
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadDouble()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if math.IsInf(value, 1) {
+			if !math.IsInf(v, 1) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else if math.IsInf(value, -1) {
+			if !math.IsInf(v, -1) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else if math.IsNaN(value) {
+			if !math.IsNaN(v) {
+				t.Fatalf("Bad value for %s %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+		} else {
+			if v != value {
+				t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+			}
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolString(t *testing.T) {
-  thetype := "string"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  for _, value := range STRING_VALUES {
-    if e := p.WriteString(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if e := p.Flush(); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-    }
-    s := trans.String()
-    if s[0] != '"' || s[len(s)-1] != '"' {
-      t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
-    }
-    v := new(string)
-    if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "string"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	for _, value := range STRING_VALUES {
+		if e := p.WriteString(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if e := p.Flush(); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+		}
+		s := trans.String()
+		if s[0] != '"' || s[len(s)-1] != '"' {
+			t.Fatalf("Bad value for %s '%v', wrote '%v', expected: %v", thetype, value, s, fmt.Sprint("\"", value, "\""))
+		}
+		v := new(string)
+		if err := json.Unmarshal([]byte(s), v); err != nil || *v != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v)
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolString(t *testing.T) {
-  thetype := "string"
-  for _, value := range STRING_VALUES {
-    trans := NewTMemoryBuffer()
-    p := NewTSimpleJSONProtocol(trans)
-    trans.WriteString(JsonQuote(value))
-    trans.Flush()
-    s := trans.String()
-    v, e := p.ReadString()
-    if e != nil {
-      t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-    }
-    if v != value {
-      t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
-    }
-    v1 := new(string)
-    if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
-      t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-    }
-    trans.Reset()
-    trans.Close()
-  }
+	thetype := "string"
+	for _, value := range STRING_VALUES {
+		trans := NewTMemoryBuffer()
+		p := NewTSimpleJSONProtocol(trans)
+		trans.WriteString(JsonQuote(value))
+		trans.Flush()
+		s := trans.String()
+		v, e := p.ReadString()
+		if e != nil {
+			t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+		}
+		if v != value {
+			t.Fatalf("Bad value for %s value %v, wrote: %v, received: %v", thetype, value, s, v)
+		}
+		v1 := new(string)
+		if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != value {
+			t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+		}
+		trans.Reset()
+		trans.Close()
+	}
 }
 
 func TestWriteSimpleJSONProtocolBinary(t *testing.T) {
-  thetype := "binary"
-  value := protocol_bdata
-  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-  base64.StdEncoding.Encode(b64value, value)
-  b64String := string(b64value)
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  if e := p.WriteBinary(value); e != nil {
-    t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-  }
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
-  }
-  s := trans.String()
-  if s != fmt.Sprint("\"", b64String, "\"") {
-    t.Fatalf("Bad value for %s %v\n  wrote: %v\nexpected: %v", thetype, value, s, "\""+b64String+"\"")
-  }
-  v1 := new(string)
-  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-  }
-  trans.Close()
+	thetype := "binary"
+	value := protocol_bdata
+	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+	base64.StdEncoding.Encode(b64value, value)
+	b64String := string(b64value)
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	if e := p.WriteBinary(value); e != nil {
+		t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+	}
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s value %v due to error flushing: %s", thetype, value, e.Error())
+	}
+	s := trans.String()
+	if s != fmt.Sprint("\"", b64String, "\"") {
+		t.Fatalf("Bad value for %s %v\n  wrote: %v\nexpected: %v", thetype, value, s, "\""+b64String+"\"")
+	}
+	v1 := new(string)
+	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+	}
+	trans.Close()
 }
 
 func TestReadSimpleJSONProtocolBinary(t *testing.T) {
-  thetype := "binary"
-  value := protocol_bdata
-  b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
-  base64.StdEncoding.Encode(b64value, value)
-  b64String := string(b64value)
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  trans.WriteString(JsonQuote(b64String))
-  trans.Flush()
-  s := trans.String()
-  v, e := p.ReadBinary()
-  if e != nil {
-    t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
-  }
-  if len(v) != len(value) {
-    t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
-  }
-  for i := 0; i < len(v); i++ {
-    if v[i] != value[i] {
-      t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
-    }
-  }
-  v1 := new(string)
-  if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
-    t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
-  }
-  trans.Reset()
-  trans.Close()
+	thetype := "binary"
+	value := protocol_bdata
+	b64value := make([]byte, base64.StdEncoding.EncodedLen(len(protocol_bdata)))
+	base64.StdEncoding.Encode(b64value, value)
+	b64String := string(b64value)
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	trans.WriteString(JsonQuote(b64String))
+	trans.Flush()
+	s := trans.String()
+	v, e := p.ReadBinary()
+	if e != nil {
+		t.Fatalf("Unable to read %s value %v due to error: %s", thetype, value, e.Error())
+	}
+	if len(v) != len(value) {
+		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] != value[i] {
+			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
+		}
+	}
+	v1 := new(string)
+	if err := json.Unmarshal([]byte(s), v1); err != nil || *v1 != b64String {
+		t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, *v1)
+	}
+	trans.Reset()
+	trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolList(t *testing.T) {
-  thetype := "list"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteListEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  str1 := new([]interface{})
-  err := json.Unmarshal([]byte(str), str1)
-  if err != nil {
-    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-  }
-  l := *str1
-  if len(l) < 2 {
-    t.Fatalf("List must be at least of length two to include metadata")
-  }
-  if int(l[0].(float64)) != DOUBLE {
-    t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
-  }
-  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-    t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-  }
-  for k, value := range DOUBLE_VALUES {
-    s := l[k+2]
-    if math.IsInf(value, 1) {
-      if s.(string) != JSON_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-      }
-    } else if math.IsInf(value, 0) {
-      if s.(string) != JSON_NEGATIVE_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-      }
-    } else if math.IsNaN(value) {
-      if s.(string) != JSON_NAN {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-      }
-    } else {
-      if s.(float64) != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "list"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	p.WriteListBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteListEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	str1 := new([]interface{})
+	err := json.Unmarshal([]byte(str), str1)
+	if err != nil {
+		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+	}
+	l := *str1
+	if len(l) < 2 {
+		t.Fatalf("List must be at least of length two to include metadata")
+	}
+	if int(l[0].(float64)) != DOUBLE {
+		t.Fatal("Invalid type for list, expected: ", DOUBLE, ", but was: ", l[0])
+	}
+	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+		t.Fatal("Invalid length for list, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+	}
+	for k, value := range DOUBLE_VALUES {
+		s := l[k+2]
+		if math.IsInf(value, 1) {
+			if s.(string) != JSON_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+			}
+		} else if math.IsInf(value, 0) {
+			if s.(string) != JSON_NEGATIVE_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+			}
+		} else if math.IsNaN(value) {
+			if s.(string) != JSON_NAN {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+			}
+		} else {
+			if s.(float64) != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolSet(t *testing.T) {
-  thetype := "set"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
-  for _, value := range DOUBLE_VALUES {
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteSetEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  str1 := new([]interface{})
-  err := json.Unmarshal([]byte(str), str1)
-  if err != nil {
-    t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
-  }
-  l := *str1
-  if len(l) < 2 {
-    t.Fatalf("Set must be at least of length two to include metadata")
-  }
-  if int(l[0].(float64)) != DOUBLE {
-    t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
-  }
-  if int(l[1].(float64)) != len(DOUBLE_VALUES) {
-    t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
-  }
-  for k, value := range DOUBLE_VALUES {
-    s := l[k+2]
-    if math.IsInf(value, 1) {
-      if s.(string) != JSON_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
-      }
-    } else if math.IsInf(value, 0) {
-      if s.(string) != JSON_NEGATIVE_INFINITY {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
-      }
-    } else if math.IsNaN(value) {
-      if s.(string) != JSON_NAN {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
-      }
-    } else {
-      if s.(float64) != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "set"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	p.WriteSetBegin(TType(DOUBLE), len(DOUBLE_VALUES))
+	for _, value := range DOUBLE_VALUES {
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteSetEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	str1 := new([]interface{})
+	err := json.Unmarshal([]byte(str), str1)
+	if err != nil {
+		t.Fatalf("Unable to decode %s, wrote: %s", thetype, str)
+	}
+	l := *str1
+	if len(l) < 2 {
+		t.Fatalf("Set must be at least of length two to include metadata")
+	}
+	if int(l[0].(float64)) != DOUBLE {
+		t.Fatal("Invalid type for set, expected: ", DOUBLE, ", but was: ", l[0])
+	}
+	if int(l[1].(float64)) != len(DOUBLE_VALUES) {
+		t.Fatal("Invalid length for set, expected: ", len(DOUBLE_VALUES), ", but was: ", l[1])
+	}
+	for k, value := range DOUBLE_VALUES {
+		s := l[k+2]
+		if math.IsInf(value, 1) {
+			if s.(string) != JSON_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_INFINITY), str)
+			}
+		} else if math.IsInf(value, 0) {
+			if s.(string) != JSON_NEGATIVE_INFINITY {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY), str)
+			}
+		} else if math.IsNaN(value) {
+			if s.(string) != JSON_NAN {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %q, expected: %q, originally wrote: %q", thetype, k, value, s, JsonQuote(JSON_NAN), str)
+			}
+		} else {
+			if s.(float64) != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s'", thetype, value, s)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
 func TestWriteSimpleJSONProtocolMap(t *testing.T) {
-  thetype := "map"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
-  for k, value := range DOUBLE_VALUES {
-    if e := p.WriteI32(int32(k)); e != nil {
-      t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
-    }
-    if e := p.WriteDouble(value); e != nil {
-      t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
-    }
-  }
-  p.WriteMapEnd()
-  if e := p.Flush(); e != nil {
-    t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
-  }
-  str := trans.String()
-  if str[0] != '[' || str[len(str)-1] != ']' {
-    t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
-  }
-  l := strings.Split(str[1:len(str)-1], ",")
-  if len(l) < 3 {
-    t.Fatal("Expected list of at least length 3 for map for metadata, but was of length ", len(l))
-  }
-  expectedKeyType, _ := strconv.Atoi(l[0])
-  expectedValueType, _ := strconv.Atoi(l[1])
-  expectedSize, _ := strconv.Atoi(l[2])
-  if expectedKeyType != I32 {
-    t.Fatal("Expected map key type ", I32, ", but was ", l[0])
-  }
-  if expectedValueType != DOUBLE {
-    t.Fatal("Expected map value type ", DOUBLE, ", but was ", l[1])
-  }
-  if expectedSize != len(DOUBLE_VALUES) {
-    t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", l[2])
-  }
-  for k, value := range DOUBLE_VALUES {
-    strk := l[k*2+3]
-    strv := l[k*2+4]
-    ik, err := strconv.Atoi(strk)
-    if err != nil {
-      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, strk, string(k), err.Error())
-    }
-    if ik != k {
-      t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v", thetype, k, strk, k)
-    }
-    s := strv
-    if math.IsInf(value, 1) {
-      if s != JsonQuote(JSON_INFINITY) {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
-      }
-    } else if math.IsInf(value, 0) {
-      if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
-      }
-    } else if math.IsNaN(value) {
-      if s != JsonQuote(JSON_NAN) {
-        t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
-      }
-    } else {
-      expected := strconv.Ftoa64(value, 'g', 10)
-      if s != expected {
-        t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
-      }
-      v := float64(0)
-      if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
-        t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
-      }
-    }
-    trans.Reset()
-  }
-  trans.Close()
+	thetype := "map"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	p.WriteMapBegin(TType(I32), TType(DOUBLE), len(DOUBLE_VALUES))
+	for k, value := range DOUBLE_VALUES {
+		if e := p.WriteI32(int32(k)); e != nil {
+			t.Fatalf("Unable to write %s key int32 value %v due to error: %s", thetype, k, e.Error())
+		}
+		if e := p.WriteDouble(value); e != nil {
+			t.Fatalf("Unable to write %s value float64 value %v due to error: %s", thetype, value, e.Error())
+		}
+	}
+	p.WriteMapEnd()
+	if e := p.Flush(); e != nil {
+		t.Fatalf("Unable to write %s due to error flushing: %s", thetype, e.Error())
+	}
+	str := trans.String()
+	if str[0] != '[' || str[len(str)-1] != ']' {
+		t.Fatalf("Bad value for %s, wrote: %q, in go: %q", thetype, str, DOUBLE_VALUES)
+	}
+	l := strings.Split(str[1:len(str)-1], ",")
+	if len(l) < 3 {
+		t.Fatal("Expected list of at least length 3 for map for metadata, but was of length ", len(l))
+	}
+	expectedKeyType, _ := strconv.Atoi(l[0])
+	expectedValueType, _ := strconv.Atoi(l[1])
+	expectedSize, _ := strconv.Atoi(l[2])
+	if expectedKeyType != I32 {
+		t.Fatal("Expected map key type ", I32, ", but was ", l[0])
+	}
+	if expectedValueType != DOUBLE {
+		t.Fatal("Expected map value type ", DOUBLE, ", but was ", l[1])
+	}
+	if expectedSize != len(DOUBLE_VALUES) {
+		t.Fatal("Expected map size of ", len(DOUBLE_VALUES), ", but was ", l[2])
+	}
+	for k, value := range DOUBLE_VALUES {
+		strk := l[k*2+3]
+		strv := l[k*2+4]
+		ik, err := strconv.Atoi(strk)
+		if err != nil {
+			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v, error: %s", thetype, k, strk, string(k), err.Error())
+		}
+		if ik != k {
+			t.Fatalf("Bad value for %s index %v, wrote: %v, expected: %v", thetype, k, strk, k)
+		}
+		s := strv
+		if math.IsInf(value, 1) {
+			if s != JsonQuote(JSON_INFINITY) {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_INFINITY))
+			}
+		} else if math.IsInf(value, 0) {
+			if s != JsonQuote(JSON_NEGATIVE_INFINITY) {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NEGATIVE_INFINITY))
+			}
+		} else if math.IsNaN(value) {
+			if s != JsonQuote(JSON_NAN) {
+				t.Fatalf("Bad value for %s at index %v  %v, wrote: %v, expected: %v", thetype, k, value, s, JsonQuote(JSON_NAN))
+			}
+		} else {
+			expected := strconv.FormatFloat(value, 'g', 10, 64)
+			if s != expected {
+				t.Fatalf("Bad value for %s at index %v %v, wrote: %v, expected %v", thetype, k, value, s, expected)
+			}
+			v := float64(0)
+			if err := json.Unmarshal([]byte(s), &v); err != nil || v != value {
+				t.Fatalf("Bad json-decoded value for %s %v, wrote: '%s', expected: '%v'", thetype, value, s, v)
+			}
+		}
+		trans.Reset()
+	}
+	trans.Close()
 }
 
-
 func TestReadWriteSimpleJSONStruct(t *testing.T) {
-  thetype := "struct"
-  trans := NewTMemoryBuffer()
-  p := NewTSimpleJSONProtocol(trans)
-  orig := NewWork()
-  orig.Num1 = 25
-  orig.Num2 = 102
-  orig.Op = ADD
-  orig.Comment = "Add: 25 + 102"
-  if e := orig.Write(p); e != nil {
-    t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
-  }
-  t.Log("Memory buffer contents: ", trans.String())
-  read := NewWork()
-  e := read.Read(p)
-  t.Logf("Read %s value: %#v", thetype, read)
-  if e != nil {
-    t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
-  }
-  if !orig.Equals(read) {
-    t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
-  }
+	thetype := "struct"
+	trans := NewTMemoryBuffer()
+	p := NewTSimpleJSONProtocol(trans)
+	orig := NewWork()
+	orig.Num1 = 25
+	orig.Num2 = 102
+	orig.Op = ADD
+	orig.Comment = "Add: 25 + 102"
+	if e := orig.Write(p); e != nil {
+		t.Fatalf("Unable to write %s value %#v due to error: %s", thetype, orig, e.Error())
+	}
+	t.Log("Memory buffer contents: ", trans.String())
+	read := NewWork()
+	e := read.Read(p)
+	t.Logf("Read %s value: %#v", thetype, read)
+	if e != nil {
+		t.Fatalf("Unable to read %s due to error: %s", thetype, e.Error())
+	}
+	if !orig.Equals(read) {
+		t.Fatalf("Original Write != Read: %#v != %#v ", orig, read)
+	}
 }
 
 func TestReadWriteSimpleJSONProtocol(t *testing.T) {
-  ReadWriteProtocolTest(t, NewTSimpleJSONProtocolFactory())
+	ReadWriteProtocolTest(t, NewTSimpleJSONProtocolFactory())
 }

--- a/lib/go/thrift/tsocket.go
+++ b/lib/go/thrift/tsocket.go
@@ -22,6 +22,7 @@ package thrift
 import (
   "net"
   "bytes"
+  "time"
 )
 
 /**
@@ -90,13 +91,15 @@ func NewTSocket(address net.Addr, nsecTimeout int64) *TSocket {
  */
 func (p *TSocket) SetTimeout(nsecTimeout int64) error {
   p.nsecTimeout = nsecTimeout
-  if p.IsOpen() {
-    if err := p.conn.SetTimeout(nsecTimeout); err != nil {
-      LOGGER.Print("Could not set socket timeout.", err)
-      return err
-    }
-  }
   return nil
+}
+
+func (p *TSocket) pushDeadline() {
+  if p.nsecTimeout > 0 {
+    p.conn.SetDeadline(time.Now().Add(time.Duration(p.nsecTimeout)))
+  } else {
+    p.conn.SetDeadline(time.Time{})
+  }
 }
 
 /**
@@ -133,12 +136,16 @@ func (p *TSocket) Open() error {
     return NewTTransportException(NOT_OPEN, "Cannot open bad address.")
   }
   var err error
-  if p.conn, err = net.Dial(p.addr.Network(), p.addr.String()); err != nil {
-    LOGGER.Print("Could not open socket", err.Error())
-    return NewTTransportException(NOT_OPEN, err.Error())
-  }
-  if p.conn != nil {
-    p.conn.SetTimeout(p.nsecTimeout)
+  if p.nsecTimeout > 0 {
+    if p.conn, err = net.DialTimeout(p.addr.Network(), p.addr.String(), time.Duration(p.nsecTimeout)); err != nil {
+      LOGGER.Print("Could not open socket", err.Error())
+      return NewTTransportException(NOT_OPEN, err.Error())
+    }
+  } else {
+    if p.conn, err = net.Dial(p.addr.Network(), p.addr.String()); err != nil {
+      LOGGER.Print("Could not open socket", err.Error())
+      return NewTTransportException(NOT_OPEN, err.Error())
+    }
   }
   return nil
 }
@@ -164,6 +171,7 @@ func (p *TSocket) Read(buf []byte) (int, error) {
   if !p.IsOpen() {
     return 0, NewTTransportException(NOT_OPEN, "Connection not open")
   }
+  p.pushDeadline()
   n, err := p.conn.Read(buf)
   return n, NewTTransportExceptionFromOsError(err)
 }
@@ -177,6 +185,7 @@ func (p *TSocket) Write(buf []byte) (int, error) {
   if !p.IsOpen() {
     return 0, NewTTransportException(NOT_OPEN, "Connection not open")
   }
+  p.pushDeadline()
   p.writeBuffer.Write(buf)
   return len(buf), nil
 }


### PR DESCRIPTION
This pull request contains two changes:
- Changes in the socket classes to remove the use of SetTimeout and replace it with SetDeadline. This is required for the weekly version of Go since SetTimeout was removed. Following the guidelines in the Go docs I am calling SetDeadline just before any Read/Write method.
- Automatic fixes in the code, performed by "go fix", which involve the use of the strconv package. Unfortunately this tool also appears to run "go fmt" internally so the file whitespace is changed and so it appears a lot of lines where changed. This is limited to only the JSON tests.
