### PR TITLE
Go1 Updates

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -2459,7 +2459,7 @@ void t_go_generator::generate_deserialize_container(ofstream &out,
       indent() <<"  return thrift.NewTProtocolExceptionReadField(" <<
                            -1 << ", \"" <<
                            escape_string(prefix) << "\", \"\", " << 
-                           err << "); }" << endl <<
+                           err << "); " << endl <<
       indent() << "}" << endl <<
       indent() << prefix << eq << "thrift.NewTSet(" << etype << ", " << size << ")" << endl;
   } else if (ttype->is_list()) {

--- a/configure.ac
+++ b/configure.ac
@@ -17,13 +17,13 @@
 # under the License.
 #
 
-AC_PREREQ(2.61)
+AC_PREREQ(2.65)
 
-AC_INIT([thrift], [0.7.0-dev])
+AC_INIT([thrift], [0.8.0])
 
 AC_CONFIG_AUX_DIR([.])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([1.9 tar-ustar])
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_VAR([PY_PREFIX], [Prefix for installing Python modules.
@@ -56,9 +56,16 @@ AC_ARG_VAR([PHP_CONFIG_PREFIX],
            Default = "/etc/php.d"])
 AS_IF([test "x$PHP_CONFIG_PREFIX" = x], [PHP_CONFIG_PREFIX="/etc/php.d"])
 
+AC_ARG_VAR([INSTALLDIRS], [When installing Perl modules, specifies which
+                           of the sets of installation directories
+                           to choose: perl, site or vendor.
+                           Default = "vendor"])
+AS_IF([test "x$INSTALLDIRS" = x], [INSTALLDIRS="vendor"])
+
 AC_ARG_VAR([PERL_PREFIX], [Prefix for installing Perl modules.
                            (Normal --prefix is ignored for Perl because
                            Perl has different conventions.)
+                           Ignored, when INSTALLDIRS set to site or vendor.
                            Default = "/usr/local/lib"])
 AS_IF([test "x$PERL_PREFIX" = x], [PERL_PREFIX="/usr/local"])
 
@@ -82,6 +89,10 @@ AC_ARG_VAR([GOBIN], [Binary directory for Go.
                            Default = "/usr/local/bin"])
 AS_IF([test "x$GOBIN" = x], [GOBIN="/usr/local/bin"])
 
+AC_ARG_VAR([GOTOOLDIR], [Binary tool directory for Go.
+                           Default = "/usr/local/bin"])
+AS_IF([test "x$GOTOOLDIR" = x], [GOBIN="/usr/local/bin"])
+
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXX
@@ -102,7 +113,7 @@ AX_THRIFT_LIB(cpp, [C++], yes)
 have_cpp=no
 if test "$with_cpp" = "yes";  then
   AX_BOOST_BASE([1.33.1])
-  if test "x$succeeded" == "xyes" ; then
+  if test "x$succeeded" = "xyes" ; then
     have_cpp="yes"
   fi
 
@@ -141,15 +152,7 @@ AX_THRIFT_LIB(java, [Java], yes)
 if test "$with_java" = "yes";  then
   AX_JAVAC_AND_JAVA
   AC_PATH_PROG([ANT], [ant])
-  AX_CHECK_JAVA_CLASS(org.slf4j.Logger)
-  have_slf4j="$success"
-  AX_CHECK_JAVA_CLASS(org.slf4j.impl.SimpleLogger)
-  have_slf4j_simple="$success"
-  AX_CHECK_JAVA_CLASS(org.apache.commons.lang.builder.HashCodeBuilder)
-  have_hashcode="$success"
-  if test "x$have_slf4j_simple" = "xyes" && test "x$have_slf4j" = "xyes" && test "x$have_hashcode" = "xyes" ; then
-    ANT_FLAGS="$ANT_FLAGS -Dnoivy="
-  fi
+  AX_CHECK_ANT_VERSION($ANT, 1.7)
   AC_SUBST(CLASSPATH)
   AC_SUBST(ANT_FLAGS)
   if test "x$JAVAC" != "x" && test "x$JAVAC" != "x" && test "x$ANT" != "x" ; then
@@ -221,13 +224,14 @@ AX_THRIFT_LIB(ruby, [Ruby], yes)
 have_ruby=no
 if test "$with_ruby" = "yes"; then
   AC_PATH_PROG([RUBY], [ruby])
-  AC_PATH_PROG([RSPEC], [spec])
-  if test "x$RUBY" != "x" ; then
+  AC_PATH_PROG([RAKE], [rake])
+  AC_PATH_PROG([BUNDLER], [bundle])
+  if test "x$RUBY" != "x" -a "x$RAKE" != "x"; then
     have_ruby="yes"
   fi
 fi
 AM_CONDITIONAL(WITH_RUBY, [test "$have_ruby" = "yes"])
-AM_CONDITIONAL(HAVE_RSPEC, [test "x$RSPEC" != "x"])
+AM_CONDITIONAL(HAVE_BUNDLER, [test "x$BUNDLER" != "x"])
 
 AX_THRIFT_LIB(haskell, [Haskell], yes)
 have_haskell=no
@@ -263,19 +267,25 @@ if test "$with_go" = "yes";  then
     GOARCH_NUM=6
     ;;
   esac
-  GO_C=${GOBIN}/${GOARCH_NUM}g
-  GO_L=${GOBIN}/${GOARCH_NUM}l
-  GOMAKE=${GOBIN}/gomake
-  GOINSTALL=${GOBIN}/goinstall
+  GO_C=${GOTOOLDIR}/${GOARCH_NUM}g
+  GO_L=${GOTOOLDIR}/${GOARCH_NUM}l
+  GOGO=${GOBIN}/go
+  GOMAKE=${GOGO} build
+  GOINSTALL=${GOGO} install
   AC_PATH_PROG([GO_C], [${GOARCH_NUM}g])
   AC_PATH_PROG([GO_L], [${GOARCH_NUM}l])
-  AC_PATH_PROG([GOMAKE], [gomake])
-  AC_PATH_PROG([GOINSTALL], [goinstall])
-  if [[ -x "$GO_C" -a -x "$GO_L" -a -x "$GOMAKE" -a -x "$GOINSTALL" ]] ; then
+  AC_PATH_PROG([GOGO], [go])
+  if [[ -x "$GO_C" -a -x "$GO_L" -a -x "$GOGO" ]] ; then
     have_go="yes"
   fi
 fi
 AM_CONDITIONAL(WITH_GO, [test "$have_go" = "yes"])
+
+have_tests=yes
+if test "$with_tests" = "no"; then
+  have_tests="no"
+fi
+AM_CONDITIONAL(WITH_TESTS, [test "$have_tests" = "yes"])
 
 AC_C_CONST
 AC_C_INLINE
@@ -298,9 +308,15 @@ AC_CHECK_HEADERS([stddef.h])
 AC_CHECK_HEADERS([stdlib.h])
 AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([sys/time.h])
+AC_CHECK_HEADERS([sys/un.h])
+AC_CHECK_HEADERS([sys/poll.h])
+AC_CHECK_HEADERS([sys/resource.h])
 AC_CHECK_HEADERS([unistd.h])
 AC_CHECK_HEADERS([libintl.h])
 AC_CHECK_HEADERS([malloc.h])
+AC_CHECK_HEADERS([openssl/ssl.h])
+AC_CHECK_HEADERS([openssl/rand.h])
+AC_CHECK_HEADERS([openssl/x509v3.h])
 
 AC_CHECK_LIB(pthread, pthread_create)
 dnl NOTE(dreiss): I haven't been able to find any really solid docs
@@ -310,6 +326,21 @@ dnl of the POSIX Real-Time Extensions.  This seems necessary on Linux,
 dnl and we haven't yet found a system where this is a problem.
 AC_CHECK_LIB(rt, clock_gettime)
 AC_CHECK_LIB(socket, setsockopt)
+
+if test "$have_cpp" = "yes" ; then
+# mingw toolchain used to build "Thrift Compiler for Windows"
+# does not support libcrypto, so we just check if we building the cpp library
+AC_CHECK_LIB(crypto,
+    BN_init,
+    [AC_CHECK_LIB(ssl,
+        SSL_ctrl,
+        [LIBS="-lssl -lcrypto $LIBS"],
+        [AC_MSG_ERROR(["Error: libssl required"])],
+        -lcrypto
+    )],
+    [AC_MSG_ERROR(["Error: libcrypto required."])]
+)
+fi
 
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T
@@ -382,45 +413,6 @@ if false ; then
   AC_FUNC_ERROR_AT_LINE
 fi
 
-AX_THRIFT_GEN(cpp, [C++], yes)
-AM_CONDITIONAL([THRIFT_GEN_cpp], [test "$ax_thrift_gen_cpp" = "yes"])
-AX_THRIFT_GEN(c_glib, [C (GLib)], yes)
-AM_CONDITIONAL([THRIFT_GEN_c_glib], [test "$ax_thrift_gen_c_glib" = "yes"])
-AX_THRIFT_GEN(java, [Java], yes)
-AM_CONDITIONAL([THRIFT_GEN_java], [test "$ax_thrift_gen_java" = "yes"])
-AX_THRIFT_GEN(as3, [AS3], yes)
-AM_CONDITIONAL([THRIFT_GEN_as3], [test "$ax_thrift_gen_as3" = "yes"])
-AX_THRIFT_GEN(csharp, [C#], yes)
-AM_CONDITIONAL([THRIFT_GEN_csharp], [test "$ax_thrift_gen_csharp" = "yes"])
-AX_THRIFT_GEN(py, [Python], yes)
-AM_CONDITIONAL([THRIFT_GEN_py], [test "$ax_thrift_gen_py" = "yes"])
-AX_THRIFT_GEN(rb, [Ruby], yes)
-AM_CONDITIONAL([THRIFT_GEN_rb], [test "$ax_thrift_gen_rb" = "yes"])
-AX_THRIFT_GEN(perl, [Perl], yes)
-AM_CONDITIONAL([THRIFT_GEN_perl], [test "$ax_thrift_gen_perl" = "yes"])
-AX_THRIFT_GEN(php, [PHP], yes)
-AM_CONDITIONAL([THRIFT_GEN_php], [test "$ax_thrift_gen_php" = "yes"])
-AX_THRIFT_GEN(erl, [Erlang], yes)
-AM_CONDITIONAL([THRIFT_GEN_erl], [test "$ax_thrift_gen_erl" = "yes"])
-AX_THRIFT_GEN(cocoa, [Cocoa], yes)
-AM_CONDITIONAL([THRIFT_GEN_cocoa], [test "$ax_thrift_gen_cocoa" = "yes"])
-AX_THRIFT_GEN(st, [Smalltalk], yes)
-AM_CONDITIONAL([THRIFT_GEN_st], [test "$ax_thrift_gen_st" = "yes"])
-AX_THRIFT_GEN(ocaml, [OCaml], yes)
-AM_CONDITIONAL([THRIFT_GEN_ocaml], [test "$ax_thrift_gen_ocaml" = "yes"])
-AX_THRIFT_GEN(hs, [Haskell], yes)
-AM_CONDITIONAL([THRIFT_GEN_hs], [test "$ax_thrift_gen_hs" = "yes"])
-AX_THRIFT_GEN(xsd, [XSD], yes)
-AM_CONDITIONAL([THRIFT_GEN_xsd], [test "$ax_thrift_gen_xsd" = "yes"])
-AX_THRIFT_GEN(html, [HTML], yes)
-AM_CONDITIONAL([THRIFT_GEN_html], [test "$ax_thrift_gen_html" = "yes"])
-AX_THRIFT_GEN(js, [JavaScript], yes)
-AM_CONDITIONAL([THRIFT_GEN_js], [test "$ax_thrift_gen_js" = "yes"])
-AX_THRIFT_GEN(javame, [JavaME], yes)
-AM_CONDITIONAL([THRIFT_GEN_javame], [test "$ax_thrift_gen_javame" = "yes"])
-AX_THRIFT_GEN(go, [GO_C], yes)
-AM_CONDITIONAL([THRIFT_GEN_go], [test "$ax_thrift_gen_go" = "yes"])
-
 # --- Coverage hooks ---
 
 AC_ARG_ENABLE(coverage,
@@ -444,6 +436,24 @@ AC_SUBST(GCOV_CFLAGS)
 AC_SUBST(GCOV_CXXFLAGS)
 AC_SUBST(GCOV_LDFLAGS)
 
+AC_ARG_ENABLE(boostthreads,
+              [  --enable-boostthreads      use boost threads, instead of POSIX pthread (experimental) ],
+              [case "${enableval}" in
+                yes) ENABLE_BOOSTTHREADS=1 ;;
+                no) ENABLE_BOOSTTHREADS=0 ;;
+                *) AC_MSG_ERROR(bad value ${enableval} for --enable-cov) ;;
+              esac],
+              [ENABLE_BOOSTTHREADS=2])
+
+
+if test "x[$]ENABLE_BOOSTTHREADS" = "x1"; then
+  AC_MSG_WARN(enable boostthreads)
+  AC_DEFINE([USE_BOOST_THREAD], [1], [experimental --enable-boostthreads that replaces POSIX pthread by boost::thread])
+  LIBS="-lboost_thread $LIBS"
+fi
+
+AM_CONDITIONAL([WITH_BOOSTTHREADS], [test "x[$]ENABLE_BOOSTTHREADS" = "x1"])
+
 AC_CONFIG_HEADERS(config.h:config.hin)
 
 AC_CONFIG_FILES([
@@ -461,15 +471,17 @@ AC_CONFIG_FILES([
   lib/c_glib/test/Makefile
   lib/csharp/Makefile
   lib/erl/Makefile
-  lib/erl/src/Makefile
+  lib/erl/src/thrift.app.src
   lib/hs/Makefile
   lib/java/Makefile
+  lib/js/test/Makefile
   lib/perl/Makefile
   lib/perl/test/Makefile
   lib/php/Makefile
   lib/py/Makefile
   lib/rb/Makefile
   test/Makefile
+  test/cpp/Makefile
   test/hs/Makefile
   test/py/Makefile
   test/py.twisted/Makefile
@@ -521,7 +533,6 @@ fi
 if test "$have_ruby" = "yes" ; then
   echo
   echo "Using Ruby ................... : $RUBY"
-  echo "Using rspec .................. : $RSPEC"
 fi
 if test "$have_haskell" = "yes" ; then
   echo

--- a/lib/go/src/thrift/tlist.go
+++ b/lib/go/src/thrift/tlist.go
@@ -26,6 +26,7 @@ import (
 /**
  * Helper class that encapsulates list metadata.
  *
+ * Note that lists of structs requires pointers, not struct values.
  */
 type TList interface {
   TContainer

--- a/lib/go/src/thrift/tset.go
+++ b/lib/go/src/thrift/tset.go
@@ -27,6 +27,7 @@ import (
 /**
  * Helper class that encapsulates set metadata.
  *
+ * Note that lists of structs requires pointers, not struct values.
  */
 type TSet interface {
   TContainer


### PR DESCRIPTION
I fixed the configure.ac to use "go install" and "go build" instead of "gomake" and "goinstall". I also fixed a small bug in the deserializer code generation for TSets. I ran into a bug where I was using the values for structs in list and set containers instead of pointers. This cost me a while, so I added a note in the list and set documentation to note it.
