### PR TITLE
Provide a Travis CI configuration for thrift4go.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@
 
 language: erlang
 
+# N.B.(matttproud): Travis CI now includes the Go runtime packages made and
+#                   maintained by who-knows-whom.  They conflict with the
+#                   hermeticness of the test environment and are thusly
+#                   removed.
 before_install:
- - sudo apt-get install bzr git-core >/dev/null 2>&1
+ - sudo apt-get remove -y --force-yes --purge golang || true
+ - sudo apt-get remove -y --force-yes --purge golang-stable || true
+ - sudo apt-get remove -y --force-yes --purge golang-weekly || true
+ - sudo apt-get remove -y --force-yes --purge golang-tip || true
+ - test ! -x "$(which go)" || (echo "Go is still present: $(which go)" ; exit 1)
 
 install:
  - hg clone -u release https://code.google.com/p/go "${HOME}/go" >/dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# This is the Travis CI (continuous integration) configuration for thrift4go.
+#
+# Thus far, this merely checks out HEAD of thrift4go, builds it against whatever
+# the current release label for Go is, and runs the associated tests.
+# Since no canonical Go example for Travis CI exists, this one has been
+# crutched:
+#
+# https://github.com/matttproud/golang_instrumentation/blob/master/.travis.yml.
+
+language: erlang
+
+before_install:
+ - sudo apt-get install bzr git-core >/dev/null 2>&1
+
+install:
+ - hg clone -u release https://code.google.com/p/go "${HOME}/go" >/dev/null 2>&1
+ - cd "${HOME}/go/src" && ./make.bash >/dev/null 2>&1
+ - mkdir -p "${HOME}/src" || true
+ - mkdir -p "${HOME}/bin" || true
+ - mkdir -p "${HOME}/pkg" || true
+ - export GOPATH="${HOME}"
+ - export PATH=${PATH}:${HOME}/go/bin
+ - ln -s "${HOME}/builds/pomack/thrift4go" "${HOME}/src/thrift4go"
+ - mkdir -p "${HOME}/github.com/pomack/thrift4go"
+ - git clone https://github.com/pomack/thrift4go.git "${HOME}/github.com/pomack/thrift4go"
+
+script:
+ - go build -a -v github.com/pomack/thrift4go/lib/go/src/thrift/...
+ - go test -v github.com/pomack/thrift4go/lib/go/src/thrift/...


### PR DESCRIPTION
This commit adds support for Travis CI (continuous integration) in
thrift4go such that commits against the master branch will trigger
an automatic build and test run against the "release" branch du jour
of Go.  All that needs to happen after this gets incorporated is that
thrift4go register itself with http://travis-ci.org/.

This would be immensely helpful in providing automatic verification of future changes.  :-)
