### PR TITLE
Fix operating directory for Travis CI operations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,6 @@ install:
  - git clone https://github.com/pomack/thrift4go.git "${HOME}/github.com/pomack/thrift4go"
 
 script:
- - go build -a -v github.com/pomack/thrift4go/lib/go/src/thrift/...
- - go test -v github.com/pomack/thrift4go/lib/go/src/thrift/...
+ - cd "${HOME}/github.com/pomack/thrift4go/lib/go/src/thrift"
+ - go build -a -v .
+ - go test -v .


### PR DESCRIPTION
The Travis CI script could possibly be simplified further, but this
should get it working.  A complication was introduced when thrift4go
does not contain its source immediately under the git root directory as
most other Go libraries do, thusly confusing Go.
