### PR TITLE
Fix backticks due to GFM markdown regression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,45 +21,45 @@ Currently generates code for the following protocols:
 Tested on Mac OS X 10.6 (Snow Leopard) and Linux ca. 2010 derivatives.
 
 To install locally, perform the following:
-  ```go get github.com/pomack/thrift4go/lib/go/thrift```
+  ``go get github.com/pomack/thrift4go/lib/go/thrift``
 
 5 files for thrift compiler (last tested on July 18, 2012):
 
-1. ```configure.ac```
-2. ```lib/Makefile.am```
-3. ```lib/go/Makefile.am```
-4. ```compiler/cpp/Makefile.am```
-5. ```compiler/cpp/src/generate/t_go_generator.cc```
+1. ``configure.ac``
+2. ``lib/Makefile.am``
+3. ``lib/go/Makefile.am``
+4. ``compiler/cpp/Makefile.am``
+5. ``compiler/cpp/src/generate/t_go_generator.cc``
 
 A tutorial has been created in the thrift4go/tutorial/go/src directory.
 
 To use this tutorial, run the following:
-    ```thrift -r --gen go <thrift_src_dir>/tutorial/tutorial.thrift```
-Build the files in the ```gen-go``` directory using ```go install``` as
+    ``thrift -r --gen go <thrift_src_dir>/tutorial/tutorial.thrift``
+Build the files in the ``gen-go`` directory using ``go install`` as
 appropriate.
-Build the files in the ```<thrift_src_dir>/tutorial/go``` directory with
-```go install``` as appropriate.
-Run the server from ```<thrift_src_dir>/tutorial/go/TutorialServerClient``` and
+Build the files in the ``<thrift_src_dir>/tutorial/go`` directory with
+``go install`` as appropriate.
+Run the server from ``<thrift_src_dir>/tutorial/go/TutorialServerClient`` and
 run the client from either
-```<thrift_src_dir>/tutorial/go/TutorialServerClient``` or
-```gen-go/tutorial/Calculator/Calculator-remote```.
+``<thrift_src_dir>/tutorial/go/TutorialServerClient`` or
+``gen-go/tutorial/Calculator/Calculator-remote``.
 
 Make sure you specify the same protocol for both the server and client.
 
 # Basic Walkthrough
 
-```thrift --gen go <thrift_src_dir>/test/ThriftTest.thrift```
+``thrift --gen go <thrift_src_dir>/test/ThriftTest.thrift``
 
-This will create ```gen-go/thrift/test/*.go``` and associated files/directories.
+This will create ``gen-go/thrift/test/*.go`` and associated files/directories.
 
-- ```gen-go/thrift/test/ThriftTest.go``` shows a service and client base
+- ``gen-go/thrift/test/ThriftTest.go`` shows a service and client base
 implementation with the associated interfaces and the ability to send/receive
 or serialize/deserialize as necessary.
 
 - ThriftTestClient is a client library designed to access the ThriftTest
 service.  No changes would need to be made here.
 
-- A ```ThriftTest/ThriftTest-remote.go``` and associated Makefile is also made
+- A ``ThriftTest/ThriftTest-remote.go`` and associated Makefile is also made
 available so you can access a remote service implementing the ThriftTest
 interface and see how the client side works under the covers.  The command-line
 arguments use the custom JSON parser, so you can just pass in JSON strings as
@@ -67,9 +67,9 @@ arguments when you need to populate a struct, which I find better than any
 other alternative.
 
 - ThriftTestProcessor implements the server side and you would want to implement
-the server handlers using ```NewThriftTestProcessor()```.
+the server handlers using ``NewThriftTestProcessor()``.
 
-- You just pass in your handler that implements the ```IThriftTest``` interface
+- You just pass in your handler that implements the ``IThriftTest`` interface
 and make sure you import the appropriate package.  Package directories/names
 are shown in the relevant Makefile.
 
@@ -86,7 +86,7 @@ as well as HEAD.
 
 - Improving idiomaticness of generated Thrift.
 
-- Generating Go interface code that would comply with ```gofmt``` tool.
+- Generating Go interface code that would comply with ``gofmt`` tool.
 
 # Continuous Integration
 


### PR DESCRIPTION
Github Flavored Markdown's rendering of triple backticks fails mid-way
through the project's README.md, whereas other renders succeed.  I have
therefore converted the triple ones to double---primarily as to
create a convention for standard use such that folks don't need to
think deliberately as to whether escaping for inner ones are needed or
not.
