### PR TITLE
Beginnings of rudimentary test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SUB_DIRECTORIES = lib
+CLEAN_DIRECTORIES = $(SUB_DIRECTORIES:%=clean-%)
+TEST_DIRECTORIES = $(SUB_DIRECTORIES:%=test-%)
+
+all: test
+
+test: $(TEST_DIRECTORIES)
+
+$(TEST_DIRECTORIES):
+	$(MAKE) -C $(@:test-%=%) test
+
+clean: $(CLEAN_DIRECTORIES)
+
+$(CLEAN_DIRECTORIES):
+	$(MAKE) -C $(@:clean-%=%) clean
+
+.PHONY: test $(TEST_DIRECTORIES) $(CLEAN_DIRECTORIES)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,0 +1,17 @@
+SUB_DIRECTORIES = go
+CLEAN_DIRECTORIES = $(SUB_DIRECTORIES:%=clean-%)
+TEST_DIRECTORIES = $(SUB_DIRECTORIES:%=test-%)
+
+all: test
+
+test: $(TEST_DIRECTORIES)
+
+$(TEST_DIRECTORIES):
+	$(MAKE) -C $(@:test-%=%) test
+
+clean: $(CLEAN_DIRECTORIES)
+
+$(CLEAN_DIRECTORIES):
+	$(MAKE) -C $(@:clean-%=%) clean
+
+.PHONY: test $(TEST_DIRECTORIES) $(CLEAN_DIRECTORIES)

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -1,0 +1,15 @@
+export GOPATH = $(CURDIR)
+ARTIFACTS = test-stamp
+
+all: test
+
+test: test-stamp
+
+test-stamp:
+	cd "$(GOPATH)" && go test -v -x thrift
+	touch $@
+
+clean:
+	-rm -f $(ARTIFACTS)
+
+.PHONY: test clean


### PR DESCRIPTION
Invoking `make` in the top-level hierarchy of thrift4go will now
trigger some basic acceptance tests, particularly the Go-based ones.

My plan is to add some follow-on cases for integration with Thrift
stable and other release points.
