### PR TITLE
Use local tests in Travis while adding build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
  - sudo apt-get remove -y --force-yes --purge golang-stable || true
  - sudo apt-get remove -y --force-yes --purge golang-weekly || true
  - sudo apt-get remove -y --force-yes --purge golang-tip || true
- - test ! -x "$(which go)" || (echo "Go is still present: $(which go)" ; exit 1)
+ - test ! -x "$(which go)" || (echo "Go is still present: $(which go)")
 
 install:
  - hg clone -u release https://code.google.com/p/go "${HOME}/go" >/dev/null 2>&1
@@ -33,6 +33,5 @@ install:
  - git clone https://github.com/pomack/thrift4go.git "${HOME}/github.com/pomack/thrift4go"
 
 script:
- - cd "${HOME}/github.com/pomack/thrift4go/lib/go/src/thrift"
- - go build -a -v .
- - go test -v .
+ - cd "${HOME}/github.com/pomack/thrift4go"
+ - make test

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -6,6 +6,7 @@ all: test
 test: test-stamp
 
 test-stamp:
+	cd "$(GOPATH)" && go build -v -x thrift
 	cd "$(GOPATH)" && go test -v -x thrift
 	touch $@
 


### PR DESCRIPTION
There was a pure Go continuous integration web app. similar to Travis CI floating around the web recently.  If I can dig up its name, it may be worth migrating to that just because of how problematic Travis has become.

Obligatory excerpt below:

Travis CI seems to update its test image frequently, and it appears,
for instance, that the team is adding native Go support.  To that
end, I will relax the removal requirement of it, putting a preference
on the release that we locally install.

Eventually, this will be replaced by just purely a `make test`
integration test target but not this second; and with this, we'll
simply have Travis CI invoke the makefile for testing versus
maintaining duplicate rules.
