### PR TITLE
Expand the configure without specification.

### DIFF
--- a/tests/merge/Makefile
+++ b/tests/merge/Makefile
@@ -25,7 +25,14 @@ test-merge-stamp: thrift-extraction tree-stamp
 	cd $(THRIFT) && ./configure \
 		--prefix=$(CURDIR)/tree \
 		--with-go \
-		--without-{c_glib,java,haskell,php,erlang,perl,python,ruby}
+		--without-c_glib \
+		--without-erlang \
+		--without-haskell \
+		--without-java \
+		--without-perl \
+		--without-php \
+		--without-python \
+		--without-ruby
 	cd $(THRIFT) && make
 	touch $@
 


### PR DESCRIPTION
I'm unsure why make on Travis does not automatically expand that
macro on that line, but I'll just remove it anyhow.  It works locally.
