### PR TITLE
Fixed: tSet.Add() not working when underlying list is empty

### DIFF
--- a/lib/go/src/thrift/tset.go
+++ b/lib/go/src/thrift/tset.go
@@ -78,12 +78,16 @@ func (p *tSet) Contains(data interface{}) bool {
 
 func (p *tSet) Add(other interface{}) {
 	if data, ok := p.elemType.CoerceData(other); ok {
-		for elem := p.l.Front(); elem != nil; elem = elem.Next() {
-			if cmp, ok := p.elemType.Compare(data, elem.Value); ok && cmp >= 0 {
-				if cmp > 0 {
-					p.l.InsertBefore(data, elem)
+		if p.l.Front() == nil {
+			p.l.PushFront(data)
+		} else {
+			for elem := p.l.Front(); elem != nil; elem = elem.Next() {
+				if cmp, ok := p.elemType.Compare(data, elem.Value); ok && cmp >= 0 {
+					if cmp > 0 {
+						p.l.InsertBefore(data, elem)
+					}
+					return
 				}
-				return
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that the tSet.Add method was not working properly. The given element is not added when the underlying list is empty.  I learnt this was the case because tSet's Add() assumed there would be at least one element in it's "container/list".List. I have added a few lines to fix this problem. The add method now add's a new element fine even if it has an empty list.
