### PR TITLE
Fixed maven build for interoperability test.

### DIFF
--- a/tests/interoperability/pom.xml
+++ b/tests/interoperability/pom.xml
@@ -32,6 +32,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptorRefs>


### PR DESCRIPTION
Edited pom.xml, added the maven compiler plugin with config. Must use java 1.6.
Java 1.6 allows @Override annotations for methods that implement an interface (which the generated code does).
This is also likely to fix the Travis-ci build.
