### PR TITLE
Removes 'thriftlib' package prefix from generated code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ is 0.8.0.  Please give the ``merge_and_build.sh`` script a run for more
 information.  It will perform the grungework of merging a local checkout of
 Thrift stable and thrift4go.
 
+Also, ``GOROOT`` must be set to the directory that contains the ``go`` binary when configuring thrift.
+
 # Areas for Future Assistance
 
 - Providing qualification tests that automatically build against Thrift stable

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Tested on Mac OS X 10.6 (Snow Leopard) and Linux ca. 2010 derivatives.
 To install locally, perform the following:
   ``go get github.com/pomack/thrift4go/lib/go/thrift``
 
+Or, to build manually:
+
+    cp -R <thrift_src_dir>/lib/go/src/thrift <go_package_src_directory>/
+    go install thrift
+
 Four files for thrift compiler (last tested on August 12, 2012):
 
 1. ``configure.ac``

--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -488,7 +488,7 @@ string t_go_generator::render_includes()
     string result = "";
 
     for (size_t i = 0; i < includes.size(); ++i) {
-        result += "import \"thriftlib/" + get_real_go_module(includes[i]) + "\"\n";
+        result += "import \"" + get_real_go_module(includes[i]) + "\"\n";
     }
 
     if (includes.size() > 0) {
@@ -1410,7 +1410,7 @@ void t_go_generator::generate_service(t_service* tservice)
 
     if (tservice->get_extends() != NULL) {
         f_service_ <<
-                   "import \"thriftlib/" << get_real_go_module(tservice->get_extends()->get_program()) << "\"" << endl;
+                   "import \"" << get_real_go_module(tservice->get_extends()->get_program()) << "\"" << endl;
     }
 
     f_service_ <<
@@ -1819,7 +1819,7 @@ void t_go_generator::generate_service_remote(t_service* tservice)
              indent() << "        \"os\"" << endl <<
              indent() << "        \"strconv\"" << endl <<
              indent() << "        \"thrift\"" << endl <<
-             indent() << "        \"thriftlib/" << service_module << "\"" << endl <<
+             indent() << "        \"" << service_module << "\"" << endl <<
              indent() << ")" << endl <<
              indent() << endl <<
              indent() << "func Usage() {" << endl <<


### PR DESCRIPTION
Removing the 'thriftlib' prefix from thrift-generated go code will make the thrift go implementation in sync with other thrift-supported languages. I believe it is the responsibility of the developer, if he/she is generating source into his/her GOPATH, to not clobber namespaces.

Minor hints have been added to the README that I wish I had known before trying to merge thrift4go and thrift main.
