### PR TITLE
Travis branch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ language: erlang
 #                   removed.
 before_install:
  - export REPO="$(pwd | sed s,^/home/travis/builds/,,g)" && echo "${REPO}"
+ - export COMMITID="$(git log -1 --pretty="%H")" && echo "${COMMITID}"
  - sudo apt-get remove -y --force-yes --purge golang || true
  - sudo apt-get remove -y --force-yes --purge golang-stable || true
  - sudo apt-get remove -y --force-yes --purge golang-weekly || true
@@ -33,7 +34,8 @@ install:
  - ln -s "${HOME}/builds/${REPO}" "${HOME}/src/thrift4go"
  - mkdir -p "${HOME}/github.com/${REPO}"
  - git clone https://github.com/${REPO}.git "${HOME}/github.com/${REPO}"
+ - cd "${HOME}/github.com/${REPO}"
+ - git checkout -qf ${COMMITID}
 
 script:
- - cd "${HOME}/github.com/${REPO}"
  - make test

--- a/tests/interoperability/pom.xml
+++ b/tests/interoperability/pom.xml
@@ -32,6 +32,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptorRefs>


### PR DESCRIPTION
Adding these changes will allow developers to test their branches on Travis-CI. Without this change: Travis always takes the master branch, which is an error.
